### PR TITLE
Support TCP_NODELAY

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,6 +54,14 @@ impl<'a> Client {
         return &mut self.connections[(self.hash_function)(key) as usize % connections_count];
     }
 
+    pub fn set_nodelay(&self, nodelay: bool) -> Result<(), MemcacheError> {
+        for conn in &self.connections {
+            conn.set_nodelay(nodelay)?;
+        }
+
+        Ok(())
+    }
+
     /// Get the memcached server version.
     ///
     /// Example:

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::io;
 use std::io::{Read, Write};
 use std::net::TcpStream;
@@ -43,9 +42,7 @@ impl Connection {
         }
         let stream = TcpStream::connect(addr.clone())?;
         let tcp_nodelay = addr.query_pairs()
-            .find(|&(ref k, ref v)| {
-                k == &Cow::Borrowed("tcp_nodelay") && v == &Cow::Borrowed("true")
-            })
+            .find(|&(ref k, ref v)| k == "tcp_nodelay" && v == "true")
             .is_some();
         stream.set_nodelay(tcp_nodelay)?;
         return Ok(Connection {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -79,3 +79,11 @@ impl Write for Connection {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn tcp_nodelay() {
+        super::Connection::connect("memcache://localhost:12345?tcp_nodelay=true").unwrap();
+    }
+}

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -10,8 +10,7 @@ use error::MemcacheError;
 
 enum Stream {
     TcpStream(TcpStream),
-    #[cfg(unix)]
-    UnixStream(UnixStream),
+    #[cfg(unix)] UnixStream(UnixStream),
 }
 
 /// The connection acts as a TCP connection to the memcached server

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -47,6 +47,17 @@ impl Connection {
             stream: Stream::TcpStream(stream),
         });
     }
+
+    pub fn set_nodelay(&self, nodelay: bool) -> Result<(), MemcacheError> {
+        match self.stream {
+            Stream::TcpStream(ref stream) => stream
+                .set_nodelay(nodelay)
+                .map_err(|e| MemcacheError::Io(e)),
+            Stream::UnixStream(_) => Err(MemcacheError::ClientError(
+                "Unix stream does not suppeed delay".into(),
+            )),
+        }
+    }
 }
 
 impl Read for Connection {


### PR DESCRIPTION
Support TCP_NODELAY for performance improvement.

I tested performance in my environment, but that was not well.
It was caused by TCP_NODELAY being disabled.

My test code is here

```rust
#[test]
fn memcache_bench() {
    extern crate memcache;

    let mut conn = memcache::Client::new("memcache://localhost:20343").unwrap();

    conn.set_nodelay(true).unwrap();
    let start = ::std::time::Instant::now();
    for _ in 0..1000 {
        let _: Option<String> = conn.get("foo").unwrap();
    }
    let elapsed = start.elapsed();
    println!(
        "Elapsed (nodelay enabled): {}.{}",
        elapsed.as_secs(),
        elapsed.subsec_nanos() / 1_000_000
    );

    conn.set_nodelay(false).unwrap();
    let start = ::std::time::Instant::now();
    for _ in 0..1000 {
        let _: Option<String> = conn.get("foo").unwrap();
    }
    let elapsed = start.elapsed();
    println!(
        "Elapsed (nodelay disabled): {}.{}",
        elapsed.as_secs(),
        elapsed.subsec_nanos() / 1_000_000
    );
}
```

And results is

```sh
$ cargo test memcache_bench --release --lib -- --nocapture
    Finished release [optimized] target(s) in 0.0 secs
     Running *****-3c8e21312813a3b5

running 1 test
Elapsed (nodelay enabled): 0.47
Elapsed (nodelay disabled): 44.163
test pool::tests::memcache_bench ... ok
```

Thanks.