### PR TITLE
Add support for UDP connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - memcached -p 12347 -d
   - memcached -p 12348 -d
   - memcached -p 12349 -d
+  - memcached -U 22345 -d
   - memcached -s /tmp/memcached.sock -d
   - memcached -s /tmp/memcached2.sock -d
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,4 @@ keywords = ["memcache", "memcached", "client", "driver"]
 [dependencies]
 byteorder = "1"
 url = "1"
-
-[dev-dependencies]
 rand = "0.3"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ memcache = "*"
 
 - [x] Binary protocal
 - [x] TCP connection
-- [ ] UDP connection
+- [x] UDP connection
 - [x] UNIX Domain socket connection
 - [ ] Automatically compress
 - [ ] Automatically serialize to JSON / msgpack etc.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ memcache = "*"
 
 ```rust
 // create connection with to memcached server node:
-let mut client = memcache::Client::new(["memcache://127.0.0.1:12345").unwrap();
+let mut client = memcache::Client::new("memcache://127.0.0.1:12345").unwrap();
 
 // flush the database
 client.flush().unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use byteorder::{WriteBytesExt, BigEndian};
-use connection::{Connection, ConnectionType};
+use connection::Connection;
 use error::MemcacheError;
 use value::{ToMemcacheValue, FromMemcacheValue};
 use packet;
@@ -37,12 +37,11 @@ fn default_hash_function(key: &str) -> u64 {
 }
 
 impl<'a> Client {
-    pub fn new<C: Connectable<'a>>(target: C, connection_type: ConnectionType) -> Result<Self, MemcacheError> {
+    pub fn new<C: Connectable<'a>>(target: C) -> Result<Self, MemcacheError> {
         let urls = target.get_urls();
         let mut connections = vec![];
-        let connection_type = connection_type as u32;
         for url in urls {
-            connections.push(Connection::connect(url, connection_type)?);
+            connections.push(Connection::connect(url)?);
         }
         return Ok(Client {
             connections: connections,
@@ -60,7 +59,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.version().unwrap();
     /// ```
     pub fn version(&mut self) -> Result<Vec<(String, String)>, MemcacheError> {
@@ -85,7 +84,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.flush().unwrap();
     /// ```
     pub fn flush(&mut self) -> Result<(), MemcacheError> {
@@ -107,7 +106,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.flush_with_delay(10).unwrap();
     /// ```
     pub fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError> {
@@ -132,7 +131,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// let _: Option<String> = client.get("foo").unwrap();
     /// ```
     pub fn get<V: FromMemcacheValue>(&mut self, key: &str) -> Result<Option<V>, MemcacheError> {
@@ -157,7 +156,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.set("foo", "42", 0).unwrap();
     /// let result: std::collections::HashMap<String, String> = client.gets(vec!["foo", "bar", "baz"]).unwrap();
     /// assert_eq!(result.len(), 1);
@@ -251,7 +250,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.set("foo", "bar", 10).unwrap();
     /// ```
     pub fn set<V: ToMemcacheValue<Connection>>(
@@ -268,7 +267,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// let key = "add_test";
     /// client.delete(key).unwrap();
     /// client.add(key, "bar", 100000000).unwrap();
@@ -287,7 +286,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// let key = "replace_test";
     /// client.set(key, "bar", 0).unwrap();
     /// client.replace(key, "baz", 100000000).unwrap();
@@ -306,7 +305,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// let key = "key_to_append";
     /// client.set(key, "hello", 0).unwrap();
     /// client.append(key, ", world!").unwrap();
@@ -340,7 +339,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// let key = "key_to_append";
     /// client.set(key, "world!", 0).unwrap();
     /// client.prepend(key, "hello, ").unwrap();
@@ -374,7 +373,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.delete("foo").unwrap();
     /// ```
     pub fn delete(&mut self, key: &str) -> Result<bool, MemcacheError> {
@@ -399,7 +398,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.increment("counter", 42).unwrap();
     /// ```
     pub fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
@@ -439,7 +438,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// client.decrement("counter", 42).unwrap();
     /// ```
     pub fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
@@ -479,7 +478,7 @@ impl<'a> Client {
     /// Example:
     ///
     /// ```rust
-    /// let mut client = memcache::Client::new("memcache://localhost:12345", memcache::ConnectionType::TCP).unwrap();
+    /// let mut client = memcache::Client::new("memcache://localhost:12345").unwrap();
     /// assert_eq!(client.touch("not_exists_key", 12345).unwrap(), false);
     /// client.set("foo", "bar", 123).unwrap();
     /// assert_eq!(client.touch("foo", 12345).unwrap(), true);
@@ -509,13 +508,13 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn unix() {
-        let mut client = super::Client::new("memcache:///tmp/memcached.sock", super::ConnectionType::TCP).unwrap();
+        let mut client = super::Client::new("memcache:///tmp/memcached.sock").unwrap();
         assert!(client.version().unwrap()[0].1 != "");
     }
 
     #[test]
     fn delete() {
-        let mut client = super::Client::new("memcache://localhost:12345", super::ConnectionType::TCP).unwrap();
+        let mut client = super::Client::new("memcache://localhost:12345").unwrap();
         client.set("an_exists_key", "value", 0).unwrap();
         assert_eq!(client.delete("an_exists_key").unwrap(), true);
         assert_eq!(client.delete("a_not_exists_key").unwrap(), false);
@@ -523,7 +522,7 @@ mod tests {
 
     #[test]
     fn increment() {
-        let mut client = super::Client::new("memcache://localhost:12345", super::ConnectionType::TCP).unwrap();
+        let mut client = super::Client::new("memcache://localhost:12345").unwrap();
         client.delete("counter").unwrap();
         client.set("counter", 321, 0).unwrap();
         assert_eq!(client.increment("counter", 123).unwrap(), 444);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,34 +1,18 @@
 use std::io;
-use std::io::{Read, Write, ErrorKind, Error};
+use std::io::{Read, Write};
 use std::net::TcpStream;
+use udp_stream::UdpStream;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use url::Url;
 #[cfg(unix)]
 use url::Host;
 use error::MemcacheError;
-use std::net::UdpSocket;
-use rand;
-use byteorder::{BigEndian, WriteBytesExt, ByteOrder};
-use std::collections::HashMap;
 
 enum Stream {
     TcpStream(TcpStream),
     UdpSocket(UdpStream),
     #[cfg(unix)] UnixStream(UnixStream),
-}
-
-pub enum ConnectionType {
-    TCP = 0,
-    UDP = 1,
-    UNIXSTREAM = 2,
-}
-
-struct UdpStream {
-    socket: UdpSocket,
-    read_buf: Vec<u8>,
-    write_buf: Vec<u8>,
-    request_id: u16,
 }
 
 /// a connection to the memcached server
@@ -38,7 +22,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub fn connect(addr: &str, connection_type: u32) -> Result<Self, MemcacheError> {
+    pub fn connect(addr: &str) -> Result<Self, MemcacheError> {
         let addr = match Url::parse(addr) {
             Ok(v) => v,
             Err(_) => return Err(MemcacheError::ClientError("Invalid memcache URL".into())),
@@ -48,19 +32,19 @@ impl Connection {
                 "memcache URL should start with 'memcache://'".into(),
             ));
         }
-        if connection_type == (ConnectionType::UDP as u32) {
-            let socket = UdpSocket::bind("0.0.0.0:0")?;
-            socket.connect(addr.clone())?;
+
+        let is_udp = addr.query_pairs()
+            .find(|&(ref k, ref v)| k == "udp" && v == "true")
+            .is_some();
+
+        if is_udp {
+            let udp_stream = Stream::UdpSocket(UdpStream::new(addr.clone())?); 
             return Ok(Connection {
-                stream: Stream::UdpSocket(UdpStream {
-                    socket: socket,
-                    read_buf: Vec::new(),
-                    write_buf: Vec::new(),
-                    request_id:  rand::random::<u16>()
-                }),
-                url: addr.into_string()
+                url: addr.into_string(),
+                stream: udp_stream
             });
         }
+
         #[cfg(unix)]
         {
             if addr.host() == Some(Host::Domain("")) && addr.port() == None {
@@ -87,29 +71,19 @@ impl Read for Connection {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self.stream {
             Stream::TcpStream(ref mut stream) => stream.read(buf),
-            Stream::UdpSocket(ref mut stream) => {
-                let mut buf_len = buf.len();
-                if buf_len > stream.read_buf.len() {
-                    buf_len = stream.read_buf.len();
-                }
-                buf[0..buf_len].copy_from_slice(&(stream.read_buf[0..buf_len]));
-                stream.read_buf.drain(0..buf_len);
-                Ok(buf_len)
-            }
+            Stream::UdpSocket(ref mut stream) => stream.read(buf),
             #[cfg(unix)]
             Stream::UnixStream(ref mut stream) => stream.read(buf),
         }
     }
 }
 
+
 impl Write for Connection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self.stream {
             Stream::TcpStream(ref mut stream) => stream.write(buf),
-            Stream::UdpSocket(ref mut stream) => { 
-                stream.write_buf.extend_from_slice(buf);
-                Ok(buf.len())
-            }
+            Stream::UdpSocket(ref mut stream) => stream.write(buf),
             #[cfg(unix)]
             Stream::UnixStream(ref mut stream) => stream.write(buf),
         }
@@ -118,54 +92,7 @@ impl Write for Connection {
     fn flush(&mut self) -> io::Result<()> {
         match self.stream {
             Stream::TcpStream(ref mut stream) => stream.flush(),
-            Stream::UdpSocket(ref mut stream) => { 
-                //udp header is 8 bytes in the begining of each datagram
-                let mut udp_header: Vec<u8> = Vec::new();
-                udp_header.write_u16::<BigEndian>(stream.request_id)?; // request id to uniquely identify response for this request
-                udp_header.write_u16::<BigEndian>(0)?; // 0 indicates this is the first datagram for this request
-                udp_header.write_u16::<BigEndian>(1)?; // total datagrams in this request (requests can only be 1 datagram long)
-                udp_header.write_u16::<BigEndian>(256)?; // reserved bytes (tested to also work with zero)
-                udp_header.reverse();
-                udp_header.iter().for_each(|i| stream.write_buf.insert(0, *i));
-                stream.socket.send(stream.write_buf.as_slice())?;
-                stream.write_buf.clear(); // clear the buffer for the next command
-
-                let mut response_datagrams: HashMap<u16, Vec<u8>> = HashMap::new();
-                let mut total_datagrams;
-                let mut remaining_datagrams = 0;
-                stream.read_buf.clear();
-                loop { // for large values, response can span multiple datagrams, so gather them all
-                    let mut buf: [u8 ; 1400] = [0 ; 1400]; // memcache udp response payload can not be longer than 1400 bytes
-                    let mut bytes_read = stream.socket.recv(&mut buf)?;
-                    if bytes_read < 8 {
-                        // make an error here to avoid panic below
-                        return Err(Error::new(ErrorKind::Other, "Invalid UDP header received"));
-                    }
-
-                    let request_id = BigEndian::read_u16(&mut buf[0..]);
-                    if stream.request_id != request_id {
-                        continue;
-                    }
-                    let sequence_no = BigEndian::read_u16(&mut buf[2..]);
-                    total_datagrams = BigEndian::read_u16(&mut buf[4..]);
-                    if remaining_datagrams == 0 {
-                        remaining_datagrams = total_datagrams;
-                    }
-
-                    let mut v: Vec<u8> = Vec::new();
-                    v.extend_from_slice(&mut buf[8..bytes_read]);
-                    response_datagrams.insert(sequence_no, v);
-                    remaining_datagrams = remaining_datagrams - 1;
-                    if remaining_datagrams == 0 {
-                        break;
-                    }
-                }
-                for i in 0..total_datagrams {
-                    stream.read_buf.append(&mut (response_datagrams[&i].clone()));
-                }
-                stream.request_id = stream.request_id + 1;
-                Ok(())
-            }
+            Stream::UdpSocket(ref mut stream) => stream.flush(),
             #[cfg(unix)]
             Stream::UnixStream(ref mut stream) => stream.flush(),
         }
@@ -176,6 +103,6 @@ impl Write for Connection {
 mod tests {
     #[test]
     fn tcp_nodelay() {
-        super::Connection::connect("memcache://localhost:12345?tcp_nodelay=true", super::ConnectionType::TCP as u32).unwrap();
+        super::Connection::connect("memcache://localhost:12345?tcp_nodelay=true").unwrap();
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::io::{Read, Write};
+use std::io::{Read, Write, ErrorKind, Error};
 use std::net::TcpStream;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
@@ -7,20 +7,38 @@ use url::Url;
 #[cfg(unix)]
 use url::Host;
 use error::MemcacheError;
+use std::net::UdpSocket;
+use rand;
+use byteorder::{BigEndian, WriteBytesExt, ByteOrder};
+use std::collections::HashMap;
 
 enum Stream {
     TcpStream(TcpStream),
+    UdpSocket(UdpStream),
     #[cfg(unix)] UnixStream(UnixStream),
 }
 
-/// The connection acts as a TCP connection to the memcached server
+pub enum ConnectionType {
+    TCP = 0,
+    UDP = 1,
+    UNIXSTREAM = 2,
+}
+
+struct UdpStream {
+    socket: UdpSocket,
+    read_buf: Vec<u8>,
+    write_buf: Vec<u8>,
+    request_id: u16,
+}
+
+/// a connection to the memcached server
 pub struct Connection {
     stream: Stream,
     pub url: String,
 }
 
 impl Connection {
-    pub fn connect(addr: &str) -> Result<Self, MemcacheError> {
+    pub fn connect(addr: &str, connection_type: u32) -> Result<Self, MemcacheError> {
         let addr = match Url::parse(addr) {
             Ok(v) => v,
             Err(_) => return Err(MemcacheError::ClientError("Invalid memcache URL".into())),
@@ -29,6 +47,19 @@ impl Connection {
             return Err(MemcacheError::ClientError(
                 "memcache URL should start with 'memcache://'".into(),
             ));
+        }
+        if connection_type == (ConnectionType::UDP as u32) {
+            let socket = UdpSocket::bind("0.0.0.0:0")?;
+            socket.connect(addr.clone())?;
+            return Ok(Connection {
+                stream: Stream::UdpSocket(UdpStream {
+                    socket: socket,
+                    read_buf: Vec::new(),
+                    write_buf: Vec::new(),
+                    request_id:  rand::random::<u16>()
+                }),
+                url: addr.into_string()
+            });
         }
         #[cfg(unix)]
         {
@@ -56,6 +87,15 @@ impl Read for Connection {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self.stream {
             Stream::TcpStream(ref mut stream) => stream.read(buf),
+            Stream::UdpSocket(ref mut stream) => {
+                let mut buf_len = buf.len();
+                if buf_len > stream.read_buf.len() {
+                    buf_len = stream.read_buf.len();
+                }
+                buf[0..buf_len].copy_from_slice(&(stream.read_buf[0..buf_len]));
+                stream.read_buf.drain(0..buf_len);
+                Ok(buf_len)
+            }
             #[cfg(unix)]
             Stream::UnixStream(ref mut stream) => stream.read(buf),
         }
@@ -66,6 +106,10 @@ impl Write for Connection {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self.stream {
             Stream::TcpStream(ref mut stream) => stream.write(buf),
+            Stream::UdpSocket(ref mut stream) => { 
+                stream.write_buf.extend_from_slice(buf);
+                Ok(buf.len())
+            }
             #[cfg(unix)]
             Stream::UnixStream(ref mut stream) => stream.write(buf),
         }
@@ -74,6 +118,54 @@ impl Write for Connection {
     fn flush(&mut self) -> io::Result<()> {
         match self.stream {
             Stream::TcpStream(ref mut stream) => stream.flush(),
+            Stream::UdpSocket(ref mut stream) => { 
+                //udp header is 8 bytes in the begining of each datagram
+                let mut udp_header: Vec<u8> = Vec::new();
+                udp_header.write_u16::<BigEndian>(stream.request_id)?; // request id to uniquely identify response for this request
+                udp_header.write_u16::<BigEndian>(0)?; // 0 indicates this is the first datagram for this request
+                udp_header.write_u16::<BigEndian>(1)?; // total datagrams in this request (requests can only be 1 datagram long)
+                udp_header.write_u16::<BigEndian>(256)?; // reserved bytes (tested to also work with zero)
+                udp_header.reverse();
+                udp_header.iter().for_each(|i| stream.write_buf.insert(0, *i));
+                stream.socket.send(stream.write_buf.as_slice())?;
+                stream.write_buf.clear(); // clear the buffer for the next command
+
+                let mut response_datagrams: HashMap<u16, Vec<u8>> = HashMap::new();
+                let mut total_datagrams;
+                let mut remaining_datagrams = 0;
+                stream.read_buf.clear();
+                loop { // for large values, response can span multiple datagrams, so gather them all
+                    let mut buf: [u8 ; 1400] = [0 ; 1400]; // memcache udp response payload can not be longer than 1400 bytes
+                    let mut bytes_read = stream.socket.recv(&mut buf)?;
+                    if bytes_read < 8 {
+                        // make an error here to avoid panic below
+                        return Err(Error::new(ErrorKind::Other, "Invalid UDP header received"));
+                    }
+
+                    let request_id = BigEndian::read_u16(&mut buf[0..]);
+                    if stream.request_id != request_id {
+                        continue;
+                    }
+                    let sequence_no = BigEndian::read_u16(&mut buf[2..]);
+                    total_datagrams = BigEndian::read_u16(&mut buf[4..]);
+                    if remaining_datagrams == 0 {
+                        remaining_datagrams = total_datagrams;
+                    }
+
+                    let mut v: Vec<u8> = Vec::new();
+                    v.extend_from_slice(&mut buf[8..bytes_read]);
+                    response_datagrams.insert(sequence_no, v);
+                    remaining_datagrams = remaining_datagrams - 1;
+                    if remaining_datagrams == 0 {
+                        break;
+                    }
+                }
+                for i in 0..total_datagrams {
+                    stream.read_buf.append(&mut (response_datagrams[&i].clone()));
+                }
+                stream.request_id = stream.request_id + 1;
+                Ok(())
+            }
             #[cfg(unix)]
             Stream::UnixStream(ref mut stream) => stream.flush(),
         }
@@ -84,6 +176,6 @@ impl Write for Connection {
 mod tests {
     #[test]
     fn tcp_nodelay() {
-        super::Connection::connect("memcache://localhost:12345?tcp_nodelay=true").unwrap();
+        super::Connection::connect("memcache://localhost:12345?tcp_nodelay=true", super::ConnectionType::TCP as u32).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ memcache = "*"
 
 ```rust
 // create connection with to memcached server node:
-let mut client = memcache::Client::new("memcache://127.0.0.1:12345", memcache::ConnectionType::TCP).unwrap();
+let mut client = memcache::Client::new("memcache://127.0.0.1:12345").unwrap();
 
 // flush the database:
 client.flush().unwrap();
@@ -60,6 +60,7 @@ extern crate url;
 extern crate rand;
 
 mod connection;
+mod udp_stream;
 mod error;
 mod value;
 mod packet;
@@ -68,4 +69,3 @@ mod client;
 pub use error::MemcacheError;
 pub use value::{ToMemcacheValue, FromMemcacheValue};
 pub use client::{Client, Connectable};
-pub use connection::ConnectionType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ memcache = "*"
 
 - <input type="checkbox"  disabled checked /> Binary protocal
 - <input type="checkbox"  disabled checked /> TCP connection
-- <input type="checkbox"  disabled /> UDP connection
+- <input type="checkbox"  disabled checked /> UDP connection
 - <input type="checkbox"  disabled checked/> UNIX Domain socket connection
 - <input type="checkbox"  disabled /> Automatically compress
 - <input type="checkbox"  disabled /> Automatically serialize to JSON / msgpack etc.
@@ -25,7 +25,7 @@ memcache = "*"
 
 ```rust
 // create connection with to memcached server node:
-let mut client = memcache::Client::new("memcache://127.0.0.1:12345").unwrap();
+let mut client = memcache::Client::new("memcache://127.0.0.1:12345", memcache::ConnectionType::TCP).unwrap();
 
 // flush the database:
 client.flush().unwrap();
@@ -57,6 +57,7 @@ assert_eq!(answer, 42);
 
 extern crate byteorder;
 extern crate url;
+extern crate rand;
 
 mod connection;
 mod error;
@@ -67,3 +68,4 @@ mod client;
 pub use error::MemcacheError;
 pub use value::{ToMemcacheValue, FromMemcacheValue};
 pub use client::{Client, Connectable};
+pub use connection::ConnectionType;

--- a/src/udp_stream.rs
+++ b/src/udp_stream.rs
@@ -1,0 +1,99 @@
+use std::io;
+use std::io::{Read, Write, ErrorKind, Error};
+use std::net::UdpSocket;
+use error::MemcacheError;
+use rand;
+use url::Url;
+use byteorder::{BigEndian, WriteBytesExt, ByteOrder};
+use std::collections::HashMap;
+use std::u16;
+
+pub struct UdpStream {
+    socket: UdpSocket,
+    read_buf: Vec<u8>,
+    write_buf: Vec<u8>,
+    request_id: u16,
+}
+
+impl UdpStream {
+    pub fn new(addr: Url) -> Result<Self, MemcacheError> {
+        let socket = UdpSocket::bind("0.0.0.0:0")?;
+        socket.connect(addr)?;
+        return Ok(UdpStream {
+                socket: socket,
+                read_buf: Vec::new(),
+                write_buf: Vec::new(),
+                request_id:  rand::random::<u16>()
+            });
+    }
+}
+
+impl Read for UdpStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut buf_len = buf.len();
+        if buf_len > self.read_buf.len() {
+            buf_len = self.read_buf.len();
+        }
+        buf[0..buf_len].copy_from_slice(&(self.read_buf[0..buf_len]));
+        self.read_buf.drain(0..buf_len);
+        Ok(buf_len)
+    }
+}
+
+impl Write for UdpStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.write_buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // udp header is 8 bytes in the begining of each datagram
+        let mut udp_header: Vec<u8> = Vec::new();
+
+        udp_header.write_u16::<BigEndian>(self.request_id)?; // request id to uniquely identify response for this request
+        udp_header.write_u16::<BigEndian>(0)?; // 0 indicates this is the first datagram for this request
+        udp_header.write_u16::<BigEndian>(1)?; // total datagrams in this request (requests can only be 1 datagram long)
+        udp_header.write_u16::<BigEndian>(0)?; // reserved bytes
+        self.write_buf.splice(0..0, udp_header.iter().cloned());
+        self.socket.send(self.write_buf.as_slice())?;
+        self.write_buf.clear(); // clear the buffer for the next command
+
+        let mut response_datagrams: HashMap<u16, Vec<u8>> = HashMap::new();
+        let mut total_datagrams;
+        let mut remaining_datagrams = 0;
+        self.read_buf.clear();
+        loop { // for large values, response can span multiple datagrams, so gather them all
+            let mut buf: [u8 ; 1400] = [0 ; 1400]; // memcache udp response payload can not be longer than 1400 bytes
+            let bytes_read = self.socket.recv(&mut buf)?;
+            if bytes_read < 8 {
+                // make an error here to avoid panic below
+                return Err(Error::new(ErrorKind::Other, "Invalid UDP header received"));
+            }
+
+            let request_id = BigEndian::read_u16(&mut buf[0..]);
+            if self.request_id != request_id { // ideally this shouldn't happen as we wait to read out response before sending another request
+                continue;
+            }
+            let sequence_no = BigEndian::read_u16(&mut buf[2..]);
+            total_datagrams = BigEndian::read_u16(&mut buf[4..]);
+            if remaining_datagrams == 0 {
+                remaining_datagrams = total_datagrams;
+            }
+
+            let mut v: Vec<u8> = Vec::new();
+            v.extend_from_slice(&mut buf[8..bytes_read]);
+            response_datagrams.insert(sequence_no, v);
+            remaining_datagrams = remaining_datagrams - 1;
+            if remaining_datagrams == 0 {
+                break;
+            }
+        }
+        for i in 0..total_datagrams {
+            self.read_buf.append(&mut (response_datagrams[&i].clone()));
+        }
+
+        self.request_id = (self.request_id % (u16::MAX)) + 1;
+        Ok(())
+    }
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -23,7 +23,7 @@ fn test() {
     if cfg!(unix) {
         urls.push("memcache:///tmp/memcached2.sock");
     }
-    let mut client = memcache::Client::new(urls).unwrap();
+    let mut client = memcache::Client::new(urls, memcache::ConnectionType::TCP).unwrap();
 
     client.version().unwrap();
 
@@ -49,6 +49,80 @@ fn test() {
 
     for key in keys {
         let value: String = client.get(key.as_str()).unwrap().unwrap();
+        assert_eq!(value, "xxx");
+    }
+}
+
+#[test]
+fn udp_test() {
+    let urls = vec!["memcache://localhost:22345"];
+    let mut client = memcache::Client::new(urls, memcache::ConnectionType::UDP).unwrap();
+
+    client.version().unwrap();
+
+    client.set("foo", "bar", 0).unwrap();
+    client.flush().unwrap();
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, None);
+
+    client.set("foo", "bar", 0).unwrap();
+    client.flush_with_delay(3).unwrap();
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, Some(String::from("bar")));
+    thread::sleep(time::Duration::from_secs(4));
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, None);
+
+    client.set("foo", "bar", 0).unwrap();
+    let value = client.add("foo", "baz", 0);
+    assert_eq!(value.is_err(), true);
+
+    client.delete("foo").unwrap();
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, None);
+
+    client.add("foo", "bar", 0).unwrap();
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, Some(String::from("bar")));
+
+    client.replace("foo", "baz", 0).unwrap();
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, Some(String::from("baz")));
+
+    client.append("foo", "bar").unwrap();
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, Some(String::from("bazbar")));
+
+    client.prepend("foo", "bar").unwrap();
+    let value: Option<String> = client.get("foo").unwrap();
+    assert_eq!(value, Some(String::from("barbazbar")));
+
+    client.set("fooo", 0, 0).unwrap();
+    client.increment("fooo", 1).unwrap();
+    let value: Option<String> = client.get("fooo").unwrap();
+    assert_eq!(value, Some(String::from("1")));
+
+    client.decrement("fooo", 1).unwrap();
+    let value: Option<String> = client.get("fooo").unwrap();
+    assert_eq!(value, Some(String::from("0")));
+
+    assert_eq!(client.touch("foooo", 123).unwrap(), false);
+    assert_eq!(client.touch("fooo", 12345).unwrap(), true);
+
+    // gets is not supported for udp
+    let value: Result<std::collections::HashMap<String, String>, _> = client.gets(vec!["foo", "fooo"]);
+    assert_eq!(value.is_ok(), false);
+
+    let mut keys: Vec<String> = Vec::new();
+    for _ in 0..1000 {
+        let key = gen_random_key();
+        keys.push(key.clone());
+        client.set(key.as_str(), "xxx", 0).unwrap();
+    }
+
+    for key in keys {
+        let value: String = client.get(key.as_str()).unwrap().unwrap();
+
         assert_eq!(value, "xxx");
     }
 }


### PR DESCRIPTION
List of commands supported (all which are currently supported for TCP except multi-get):
 - Version
 - Flush
 - Flush With Delay
 - Get
 - Set
 - Replace
 - Add
 - Append
 - Delete
 - Prepend
 - Increment
 - Decrement
 - Touch

**Design:**
 1. We use two buffers called `read_buf` and `write_buf` for UDP data transfer (See struct `UcpConnection` in connection.rs).
  Since the payload can't span multiple datagrams as it does for TCP, we choose to send requests and parse responses in the following manner:
2. For requests, we write data part by part (just like we do for TCP) in a byte vector called `write_buf`. After the command is completely written, we call flush on the connection which sends the command and accompanying data stored in `write_buf `to the server (See `flush()` in connection.rs).
3. After doing step 2, we wait for the response in the same `flush()` function. When the response from the server comes in, we store it in `read_buf `and then read it part by part just like we would do for a TCP stream.

Test results:
```
faisal@faisal-VirtualBox:~/abbasfaisal/rust-memcache$ RUST_BACKTRACE=1 cargo test -- --nocapture
   Compiling memcache v0.7.1 (file:///home/faisal/abbasfaisal/rust-memcache)
    Finished dev [unoptimized + debuginfo] target(s) in 8.74s
     Running target/debug/deps/memcache-23055108b9341b1e

running 4 tests
test client::tests::delete ... ok
test client::tests::increment ... ok
test client::tests::unix ... ok
test connection::tests::tcp_nodelay ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/tests-1ecd6df755552d8e

running 2 tests
test test ... ok
test udp_test ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests memcache

running 15 tests
test src/client.rs - client::Client::add (line 270) ... ok
test src/client.rs - client::Client::append (line 308) ... ok
test src/client.rs - client::Client::decrement (line 441) ... ok
test src/client.rs - client::Client::delete (line 376) ... ok
test src/client.rs - client::Client::flush (line 87) ... ok
test src/client.rs - client::Client::flush_with_delay (line 109) ... ok
test src/client.rs - client::Client::get (line 134) ... ok
test src/client.rs - client::Client::gets (line 159) ... ok
test src/client.rs - client::Client::increment (line 401) ... ok
test src/client.rs - client::Client::prepend (line 342) ... ok
test src/client.rs - client::Client::replace (line 289) ... ok
test src/client.rs - client::Client::set (line 253) ... ok
test src/client.rs - client::Client::touch (line 481) ... ok
test src/client.rs - client::Client::version (line 62) ... ok
test src/lib.rs -  (line 25) ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

```