### PR TITLE
Add support for Unix Socket read/write timeouts

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -18,15 +18,19 @@ pub enum Stream {
 
 impl Stream {
     pub(super) fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
-        if let Stream::Tcp(ref mut conn) = self {
-            conn.set_read_timeout(timeout)?;
+        match self {
+            Stream::Tcp(ref mut conn) => conn.set_read_timeout(timeout)?,
+            Stream::Unix(ref mut conn) => conn.set_read_timeout(timeout)?,
+            _ => (),
         }
         Ok(())
     }
 
     pub(super) fn set_write_timeout(&mut self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
-        if let Stream::Tcp(ref mut conn) = self {
-            conn.set_write_timeout(timeout)?;
+        match self {
+            Stream::Tcp(ref mut conn) => conn.set_write_timeout(timeout)?,
+            Stream::Unix(ref mut conn) => conn.set_write_timeout(timeout)?,
+            _ => (),
         }
         Ok(())
     }


### PR DESCRIPTION
This commit adds support for setting timeouts for unix socket read/write attempts. Without this, the client will be stuck attempting to read from the socket until the connection is forcibly closed.