### PR TITLE
Allow missing optional cas unique from gets response header

### DIFF
--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -188,7 +188,7 @@ impl AsciiProtocol<Stream> {
             }
 
             let header: Vec<_> = s.trim_end_matches("\r\n").split(" ").collect();
-            if header.len() != 5 {
+            if header.len() != 4 && header.len() != 5 {
                 return Err(MemcacheError::ClientError("invalid server response".into()));
             }
 


### PR DESCRIPTION
In a typical memcached gets response header we can see the `VALUE`, key,
flags and bytes. In some cases a server may add on cas unique, but it is
not a header which is required to be sent by the server.

Check out the memcached protocol docs on `gets`:
https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L228-L267

In short, a successful gets response can be of length 4 OR 5.