### PR TITLE
Better error type

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -66,11 +66,7 @@ impl Client {
         let urls = target.get_urls();
         let mut connections = vec![];
         for url in urls {
-            let parsed = match Url::parse(url.as_str()) {
-                Ok(v) => v,
-                Err(_) => return Err(MemcacheError::ClientError("Invalid memcache URL".into())),
-            };
-
+            let parsed = Url::parse(url.as_str())?;
             let mut connection = Connection::connect(&parsed)?;
 
             if parsed.has_authority() && parsed.username() != "" && parsed.password().is_some() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::error;
 use std::fmt;
 use std::io;
@@ -12,7 +13,7 @@ pub enum ClientError {
     /// The key provided was longer than 250 bytes.
     KeyTooLong,
     /// The server returned an error prefixed with CLIENT_ERROR in response to a command.
-    Error(String),
+    Error(Cow<'static, str>),
 }
 
 impl fmt::Display for ClientError {
@@ -91,7 +92,7 @@ impl MemcacheError {
 
 impl From<String> for ClientError {
     fn from(s: String) -> Self {
-        ClientError::Error(s)
+        ClientError::Error(Cow::Owned(s))
     }
 }
 
@@ -118,7 +119,6 @@ impl fmt::Display for CommandError {
 impl From<u16> for CommandError {
     fn from(status: u16) -> CommandError {
         match status {
-            0x0 => panic!("shouldn't reach here"),
             0x1 => CommandError::KeyNotFound,
             0x2 => CommandError::KeyExists,
             0x3 => CommandError::ValueTooLarge,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,37 +5,200 @@ use std::num;
 use std::str;
 use std::string;
 
+#[derive(Debug, PartialEq)]
+pub enum ClientError {
+    KeyTooLong,
+    Error(String)
+}
+
+impl fmt::Display for ClientError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ClientError::KeyTooLong => write!(f, "The provided key was too long."),
+            ClientError::Error(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl From<ClientError> for MemcacheError {
+    fn from(err: ClientError) -> Self {
+        MemcacheError::ClientError(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum ServerError {
+    BadMagic(u8),
+    BadResponse(String),
+    Error(String),
+}
+
+impl fmt::Display for ServerError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ServerError::BadMagic(e) => write!(f, "Expected 0x81 as magic in response header, but found: {:x}", e),
+            ServerError::BadResponse(s) => write!(f, "Unexpected: {} in response", s),
+            ServerError::Error(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CommandError {
+    KeyExists,
+    KeyNotFound,
+    ValueTooLarge,
+    InvalidArguments,
+    AuthenticationRequired,
+    Unknown(u16),
+    Error(String)
+}
+
+impl From<String> for CommandError {
+    fn from(s: String) -> Self {
+        CommandError::Error(s)
+    }
+}
+
+impl From<String> for ClientError {
+    fn from(s: String) -> Self {
+        ClientError::Error(s)
+    }
+}
+
+impl From<String> for ServerError {
+    fn from(s: String) -> Self {
+        ServerError::Error(s)
+    }
+}
+
+
+impl fmt::Display for CommandError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CommandError::KeyExists => write!(f, "Key already exists in the server."),
+            CommandError::KeyNotFound => write!(f, "Key was not found in the server."),
+            CommandError::ValueTooLarge => write!(f, "Value was too large."),
+            CommandError::InvalidArguments => write!(f, "Invalid arguments provided."),
+            CommandError::AuthenticationRequired => write!(f, "Authentication required."),
+            CommandError::Unknown(code) => write!(f, "Unknown error occurred with code: {}.", code),
+            CommandError::Error(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+impl From<String> for MemcacheError {
+    fn from(s: String) -> Self {
+        if s.starts_with("CLIENT_ERROR") {
+            ClientError::from(s).into()
+        } else if s.starts_with("SERVER_ERROR") {
+            ServerError::from(s).into()
+        } else if s.starts_with("ERROR") {
+            CommandError::from(s).into()
+        } else {
+            unreachable!("shouldn't reach here")
+        }
+    }
+}
+
+
+impl From<u16> for CommandError {
+    fn from(status: u16) -> CommandError {
+        match status {
+            0x0 => panic!("shouldn't reach here"),
+            0x1 => CommandError::KeyNotFound,
+            0x2 => CommandError::KeyExists,
+            0x3 => CommandError::ValueTooLarge,
+            0x4 => CommandError::InvalidArguments,
+            0x20 => CommandError::AuthenticationRequired,
+            e => CommandError::Unknown(e)
+        }
+    }
+}
+
+impl From<CommandError> for MemcacheError {
+    fn from(err: CommandError) -> Self {
+        MemcacheError::CommandError(err)
+    }
+}
+
+impl From<ServerError> for MemcacheError {
+    fn from(err: ServerError) -> Self {
+        MemcacheError::ServerError(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    Int(num::ParseIntError),
+    Float(num::ParseFloatError),
+    String(string::FromUtf8Error),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ParseError::Int(ref e) => e.fmt(f),
+            ParseError::Float(ref e) => e.fmt(f),
+            ParseError::String(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl From<ParseError> for MemcacheError {
+    fn from(err: ParseError) -> Self {
+        MemcacheError::ParseError(err)
+    }
+}
+
+impl From<string::FromUtf8Error> for MemcacheError {
+    fn from(err: string::FromUtf8Error) -> MemcacheError {
+        ParseError::String(err).into()
+    }
+}
+impl From<num::ParseIntError> for MemcacheError {
+    fn from(err: num::ParseIntError) -> MemcacheError {
+        ParseError::Int(err).into()
+    }
+}
+
+impl From<num::ParseFloatError> for MemcacheError {
+    fn from(err: num::ParseFloatError) -> MemcacheError {
+        ParseError::Float(err).into()
+    }
+}
+
 /// Stands for errors raised from rust-memcache
+// TODO: implement From<String> for the new version
 #[derive(Debug)]
 pub enum MemcacheError {
     /// Error raised when the provided memcache URL is invalid
     BadURL(String),
     /// `std::io` related errors.
-    Io(io::Error),
-    /// Error raised when unserialize value data which from memcached to String
-    FromUtf8(string::FromUtf8Error),
+    IOError(io::Error),
+    /// Client Errors
+    ClientError(ClientError),
+    /// Server Errors
+    ServerError(ServerError),
+    /// Command specific Errors
+    CommandError(CommandError),
     #[cfg(feature = "tls")]
     OpensslError(openssl::ssl::HandshakeError<std::net::TcpStream>),
-    ParseIntError(num::ParseIntError),
-    ParseFloatError(num::ParseFloatError),
-    ParseBoolError(str::ParseBoolError),
-    ClientError(String),
-    ServerError(u16),
+    /// Parse errors occurred when 
+    ParseError(ParseError),
 }
+
 
 impl fmt::Display for MemcacheError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             MemcacheError::BadURL(ref s) => s.fmt(f),
-            MemcacheError::Io(ref err) => err.fmt(f),
-            MemcacheError::FromUtf8(ref err) => err.fmt(f),
+            MemcacheError::IOError(ref err) => err.fmt(f),
             #[cfg(feature = "tls")]
             MemcacheError::OpensslError(ref err) => err.fmt(f),
-            MemcacheError::ParseIntError(ref err) => err.fmt(f),
-            MemcacheError::ParseFloatError(ref err) => err.fmt(f),
-            MemcacheError::ParseBoolError(ref err) => err.fmt(f),
-            MemcacheError::ClientError(ref s) => s.fmt(f),
-            MemcacheError::ServerError(r) => write!(f, "ServerError: {}", r),
+            MemcacheError::ParseError(ref err) => err.fmt(f),
+            MemcacheError::ClientError(ref err) => err.fmt(f),
+            MemcacheError::ServerError(ref err) => err.fmt(f),
         }
     }
 }
@@ -44,28 +207,24 @@ impl error::Error for MemcacheError {
     fn description(&self) -> &str {
         match *self {
             MemcacheError::BadURL(ref s) => s.as_str(),
-            MemcacheError::Io(ref err) => err.description(),
-            MemcacheError::FromUtf8(ref err) => err.description(),
+            MemcacheError::IOError(ref err) => err.description(),
             #[cfg(feature = "tls")]
             MemcacheError::OpensslError(ref err) => err.description(),
-            MemcacheError::ParseIntError(ref err) => err.description(),
-            MemcacheError::ParseFloatError(ref err) => err.description(),
-            MemcacheError::ParseBoolError(ref err) => err.description(),
-            MemcacheError::ClientError(ref s) => s.as_str(),
-            MemcacheError::ServerError(_) => "ServerError",
+            // TODO: implement these.
+            MemcacheError::ClientError(_) => "Client error",
+            MemcacheError::ServerError(_) => "Server error",
+            MemcacheError::ParseError(_) => "Parse error",
         }
     }
 
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             MemcacheError::BadURL(_) => None,
-            MemcacheError::Io(ref err) => err.source(),
-            MemcacheError::FromUtf8(ref err) => err.source(),
+            MemcacheError::IOError(ref err) => err.source(),
             #[cfg(feature = "tls")]
             MemcacheError::OpensslError(ref err) => err.source(),
-            MemcacheError::ParseIntError(ref err) => err.source(),
-            MemcacheError::ParseFloatError(ref err) => err.source(),
-            MemcacheError::ParseBoolError(ref err) => err.source(),
+            // TODO: implement these.
+            MemcacheError::ParseError(_) => None,
             MemcacheError::ClientError(_) => None,
             MemcacheError::ServerError(_) => None,
         }
@@ -74,15 +233,11 @@ impl error::Error for MemcacheError {
 
 impl From<io::Error> for MemcacheError {
     fn from(err: io::Error) -> MemcacheError {
-        MemcacheError::Io(err)
+        MemcacheError::IOError(err)
     }
 }
 
-impl From<string::FromUtf8Error> for MemcacheError {
-    fn from(err: string::FromUtf8Error) -> MemcacheError {
-        MemcacheError::FromUtf8(err)
-    }
-}
+
 
 #[cfg(feature = "tls")]
 impl From<openssl::error::ErrorStack> for MemcacheError {
@@ -95,35 +250,5 @@ impl From<openssl::error::ErrorStack> for MemcacheError {
 impl From<openssl::ssl::HandshakeError<std::net::TcpStream>> for MemcacheError {
     fn from(err: openssl::ssl::HandshakeError<std::net::TcpStream>) -> MemcacheError {
         MemcacheError::OpensslError(err)
-    }
-}
-
-impl From<num::ParseIntError> for MemcacheError {
-    fn from(err: num::ParseIntError) -> MemcacheError {
-        MemcacheError::ParseIntError(err)
-    }
-}
-
-impl From<num::ParseFloatError> for MemcacheError {
-    fn from(err: num::ParseFloatError) -> MemcacheError {
-        MemcacheError::ParseFloatError(err)
-    }
-}
-
-impl From<str::ParseBoolError> for MemcacheError {
-    fn from(err: str::ParseBoolError) -> MemcacheError {
-        MemcacheError::ParseBoolError(err)
-    }
-}
-
-impl From<String> for MemcacheError {
-    fn from(s: String) -> MemcacheError {
-        return MemcacheError::ClientError(s);
-    }
-}
-
-impl From<u16> for MemcacheError {
-    fn from(code: u16) -> MemcacheError {
-        return MemcacheError::ServerError(code);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,5 +80,5 @@ mod stream;
 mod value;
 
 pub use client::{Client, Connectable};
-pub use error::MemcacheError;
+pub use error::{ClientError, CommandError, MemcacheError, ServerError};
 pub use value::{FromMemcacheValue, FromMemcacheValueExt, ToMemcacheValue};

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -244,9 +244,7 @@ impl AsciiProtocol<Stream> {
         };
         match self.store(StoreCommand::Cas, key, value, &options) {
             Ok(t) => Ok(t),
-            Err(MemcacheError::ServerError(e))
-                if e == ResponseStatus::KeyExists as u16 || e == ResponseStatus::KeyNotFound as u16 =>
-            {
+            Err(MemcacheError::CommandError(e)) if e == CommandError::KeyExists || e == CommandError::KeyNotFound => {
                 Ok(false)
             }
             e => e,

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -4,7 +4,8 @@ use std::io::{BufRead, BufReader, Read, Write};
 
 use super::check_key_len;
 use client::Stats;
-use error::{CommandError, MemcacheError, ServerError};
+use error::{ClientError, CommandError, MemcacheError, ServerError};
+use std::borrow::Cow;
 use stream::Stream;
 use value::{FromMemcacheValueExt, ToMemcacheValue};
 
@@ -66,7 +67,9 @@ impl AsciiProtocol<Stream> {
         );
         if command == StoreCommand::Cas {
             if options.cas.is_none() {
-                panic!("cas value should be present");
+                Err(ClientError::Error(Cow::Borrowed(
+                    "cas_id should be present when using cas command",
+                )))?;
             }
             let cas = options.cas.unwrap();
             header += &format!(" {}", cas);

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::io::Write;
 
+use super::check_key_len;
 use byteorder::{BigEndian, WriteBytesExt};
 use client::Stats;
 use error::MemcacheError;
 use protocol::binary_packet::{self, Magic, Opcode, PacketHeader};
 use stream::Stream;
 use value::{FromMemcacheValueExt, ToMemcacheValue};
-use super::check_key_len;
 
 pub struct BinaryProtocol {
     pub stream: Stream,

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -70,7 +70,7 @@ impl BinaryProtocol {
         cas: Option<u64>,
     ) -> Result<(), MemcacheError> {
         self.send_request(opcode, key, value, expiration, cas)?;
-        binary_packet::parse_response(&mut self.stream).map(|_| ())
+        binary_packet::parse_response(&mut self.stream)?.err().map(|_| ())
     }
 
     pub(super) fn version(&mut self) -> Result<String, MemcacheError> {
@@ -93,8 +93,7 @@ impl BinaryProtocol {
         };
         request_header.write(&mut self.stream)?;
         self.stream.flush()?;
-        binary_packet::parse_response(&mut self.stream)?;
-        return Ok(());
+        binary_packet::parse_response(&mut self.stream)?.err().map(|_| ())
     }
 
     pub(super) fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError> {
@@ -108,8 +107,7 @@ impl BinaryProtocol {
         request_header.write(&mut self.stream)?;
         self.stream.write_u32::<BigEndian>(delay)?;
         self.stream.flush()?;
-        binary_packet::parse_response(&mut self.stream)?;
-        return Ok(());
+        binary_packet::parse_response(&mut self.stream)?.err().map(|_| ())
     }
 
     pub(super) fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError> {
@@ -200,7 +198,7 @@ impl BinaryProtocol {
         self.stream.write_all(key.as_bytes())?;
         value.write_to(&mut self.stream)?;
         self.stream.flush()?;
-        binary_packet::parse_response(&mut self.stream).map(|_| ())
+        binary_packet::parse_response(&mut self.stream)?.err().map(|_| ())
     }
 
     pub(super) fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError> {

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -7,6 +7,7 @@ use error::MemcacheError;
 use protocol::binary_packet::{self, Magic, Opcode, PacketHeader};
 use stream::Stream;
 use value::{FromMemcacheValueExt, ToMemcacheValue};
+use super::check_key_len;
 
 pub struct BinaryProtocol {
     pub stream: Stream,
@@ -27,8 +28,7 @@ impl BinaryProtocol {
         self.stream.write_all(key.as_bytes())?;
         value.write_to(&mut self.stream)?;
         self.stream.flush()?;
-        binary_packet::parse_start_auth_response(&mut self.stream)?;
-        return Ok(());
+        binary_packet::parse_start_auth_response(&mut self.stream).map(|_| ())
     }
 
     fn send_request<V: ToMemcacheValue<Stream>>(
@@ -39,9 +39,7 @@ impl BinaryProtocol {
         expiration: u32,
         cas: Option<u64>,
     ) -> Result<(), MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: opcode as u8,
@@ -72,7 +70,7 @@ impl BinaryProtocol {
         cas: Option<u64>,
     ) -> Result<(), MemcacheError> {
         self.send_request(opcode, key, value, expiration, cas)?;
-        return binary_packet::parse_response(&mut self.stream);
+        binary_packet::parse_response(&mut self.stream).map(|_| ())
     }
 
     pub(super) fn version(&mut self) -> Result<String, MemcacheError> {
@@ -115,9 +113,7 @@ impl BinaryProtocol {
     }
 
     pub(super) fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: Opcode::Get as u8,
@@ -133,9 +129,7 @@ impl BinaryProtocol {
 
     pub(super) fn gets<V: FromMemcacheValueExt>(&mut self, keys: &[&str]) -> Result<HashMap<String, V>, MemcacheError> {
         for key in keys {
-            if key.len() > 250 {
-                return Err(MemcacheError::ClientError(String::from("key is too long")));
-            }
+            check_key_len(key)?;
             let request_header = PacketHeader {
                 magic: Magic::Request as u8,
                 opcode: Opcode::GetKQ as u8,
@@ -194,9 +188,7 @@ impl BinaryProtocol {
     }
 
     pub(super) fn append<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: Opcode::Append as u8,
@@ -208,13 +200,11 @@ impl BinaryProtocol {
         self.stream.write_all(key.as_bytes())?;
         value.write_to(&mut self.stream)?;
         self.stream.flush()?;
-        return binary_packet::parse_response(&mut self.stream);
+        binary_packet::parse_response(&mut self.stream).map(|_| ())
     }
 
     pub(super) fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: Opcode::Prepend as u8,
@@ -226,13 +216,11 @@ impl BinaryProtocol {
         self.stream.write_all(key.as_bytes())?;
         value.write_to(&mut self.stream)?;
         self.stream.flush()?;
-        return binary_packet::parse_response(&mut self.stream);
+        binary_packet::parse_response(&mut self.stream).map(|_| ())
     }
 
     pub(super) fn delete(&mut self, key: &str) -> Result<bool, MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: Opcode::Delete as u8,
@@ -247,9 +235,7 @@ impl BinaryProtocol {
     }
 
     pub(super) fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: Opcode::Increment as u8,
@@ -273,9 +259,7 @@ impl BinaryProtocol {
     }
 
     pub(super) fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: Opcode::Decrement as u8,
@@ -299,9 +283,7 @@ impl BinaryProtocol {
     }
 
     pub(super) fn touch(&mut self, key: &str, expiration: u32) -> Result<bool, MemcacheError> {
-        if key.len() > 250 {
-            return Err(MemcacheError::ClientError(String::from("key is too long")));
-        }
+        check_key_len(key)?;
         let request_header = PacketHeader {
             magic: Magic::Request as u8,
             opcode: Opcode::Touch as u8,

--- a/src/protocol/binary_packet.rs
+++ b/src/protocol/binary_packet.rs
@@ -110,7 +110,7 @@ pub fn parse_response<R: io::Read>(reader: &mut R) -> Result<Response, MemcacheE
         let mut key = vec![0x0; header.key_length as usize];
         reader.read_exact(key.as_mut_slice())?;
 
-        // TODO: return error if total_body_length > extras_length + key_length
+        // TODO: return error if total_body_length < extras_length + key_length
         let mut value = vec![
             0x0;
             (header.total_body_length - u32::from(header.key_length) - u32::from(header.extras_length))

--- a/src/protocol/binary_packet.rs
+++ b/src/protocol/binary_packet.rs
@@ -1,4 +1,3 @@
-use super::ResponseStatus;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use error::{CommandError, MemcacheError, ServerError};
 use std::collections::HashMap;

--- a/src/protocol/binary_packet.rs
+++ b/src/protocol/binary_packet.rs
@@ -1,9 +1,10 @@
 use super::ResponseStatus;
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-use error::MemcacheError;
+use error::{ServerError, MemcacheError, CommandError};
 use std::collections::HashMap;
-use std::io;
+use std::io::{self, Cursor};
 use value::FromMemcacheValueExt;
+use super::ResponseStatus;
 
 #[allow(dead_code)]
 pub enum Opcode {
@@ -73,10 +74,7 @@ impl PacketHeader {
     pub fn read<R: io::Read>(reader: &mut R) -> Result<PacketHeader, MemcacheError> {
         let magic = reader.read_u8()?;
         if magic != Magic::Response as u8 {
-            return Err(MemcacheError::ClientError(format!(
-                "Bad magic number in response header: {}",
-                magic
-            )));
+            return Err(ServerError::BadMagic(magic).into());
         }
         let header = PacketHeader {
             magic,
@@ -93,19 +91,38 @@ impl PacketHeader {
     }
 }
 
-pub fn parse_cas_response<R: io::Read>(stream: &mut R) -> Result<bool, MemcacheError> {
-    let header = PacketHeader::read(stream)?;
+struct Response {
+    header: PacketHeader,
+    key: Vec<u8>,
+    extras: Vec<u8>,
+    value: Vec<u8>,
+}
+
+pub fn parse_response<R: io::Read>(reader: &mut R) -> Result<Response, MemcacheError> {
+    let header = PacketHeader::read(reader)?;
     let status = header.vbucket_id_or_status;
-    // In case of KeyExists and KeyNotFound errors, there is also an error string
-    let value_len = header.total_body_length - u32::from(header.extras_length);
-    let mut err_message = vec![0x0; value_len as usize];
-    stream.read_exact(err_message.as_mut_slice())?;
-    if status == ResponseStatus::KeyExists as u16 || status == ResponseStatus::KeyNotFound as u16 {
-        Ok(false)
-    } else if status == ResponseStatus::NoError as u16 {
-        Ok(true)
+    if status != ResponseStatus::NoError as u16 {
+        Err(CommandError::from(status).into())?
     } else {
-        Err(MemcacheError::from(header.vbucket_id_or_status))
+        let mut extras = vec![0x0; header.extras_length as usize];
+        reader.read_exact(extras.as_mut_slice())?;
+
+        let mut key = vec![0x0; header.key_length as usize];
+        reader.read_exact(key.as_mut_slice())?;
+
+        // TODO: return error if total_body_length > extras_length + key_length
+        let mut value = vec![0x0; (header.total_body_length - u32::from(header.key_length) - u32::from(header.extras_length)) as usize];
+        reader.read_exact(value.as_mut_slice())?;
+
+        Ok(Response { header, key, extras, value })
+    }
+}
+
+pub fn parse_cas_response<R: io::Read>(reader: &mut R) -> Result<bool, MemcacheError> {
+    match parse_response(reader) {
+        Err(MemcacheError::CommandError(e)) if e == CommandError::KeyNotFound || e == CommandError::KeyExists => Ok(false),
+        Ok(_) => Ok(true),
+        Err(e) => Err(e)
     }
 }
 
@@ -114,39 +131,25 @@ pub fn parse_response<R: io::Read>(reader: &mut R) -> Result<(), MemcacheError> 
     let mut buffer = vec![0; header.total_body_length as usize];
     reader.read_exact(buffer.as_mut_slice())?;
     if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-        return Err(MemcacheError::from(header.vbucket_id_or_status));
+        return Err(CommandError::from(header.vbucket_id_or_status).into());
     }
     return Ok(());
 }
 
 pub fn parse_version_response<R: io::Read>(reader: &mut R) -> Result<String, MemcacheError> {
-    let header = PacketHeader::read(reader)?;
-    if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-        return Err(MemcacheError::from(header.vbucket_id_or_status));
-    }
-    let mut buffer = vec![0; header.total_body_length as usize];
-    reader.read_exact(buffer.as_mut_slice())?;
-    return Ok(String::from_utf8(buffer)?);
+    let Response { value, .. } = parse_response(reader)?;
+    Ok(String::from_utf8(value)?)
 }
 
 pub fn parse_get_response<R: io::Read, V: FromMemcacheValueExt>(reader: &mut R) -> Result<Option<V>, MemcacheError> {
-    let header = PacketHeader::read(reader)?;
-    if header.vbucket_id_or_status == ResponseStatus::KeyNotFound as u16 {
-        let mut buffer = vec![0; header.total_body_length as usize];
-        reader.read_exact(buffer.as_mut_slice())?;
-        return Ok(None);
-    } else if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-        return Err(MemcacheError::from(header.vbucket_id_or_status));
+    match parse_response(reader) {
+        Ok(Response { header, extras, value, ..}) => {
+            let flags = Cursor::new(extras).read_u32::<BigEndian>()?;
+            Ok(Some(FromMemcacheValueExt::from_memcache_value(value, flags, Some(header.cas))?))
+        }
+        Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(None),
+        Err(e) => Err(e)
     }
-    let flags = reader.read_u32::<BigEndian>()?;
-    let value_length = header.total_body_length - u32::from(header.extras_length);
-    let mut buffer = vec![0; value_length as usize];
-    reader.read_exact(buffer.as_mut_slice())?;
-    return Ok(Some(FromMemcacheValueExt::from_memcache_value(
-        buffer,
-        flags,
-        Some(header.cas),
-    )?));
 }
 
 pub fn parse_gets_response<R: io::Read, V: FromMemcacheValueExt>(
@@ -154,93 +157,55 @@ pub fn parse_gets_response<R: io::Read, V: FromMemcacheValueExt>(
 ) -> Result<HashMap<String, V>, MemcacheError> {
     let mut result = HashMap::new();
     loop {
-        let header = PacketHeader::read(reader)?;
-        if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-            return Err(MemcacheError::from(header.vbucket_id_or_status));
-        }
+        let Response { header, key, extras, value } = parse_response(reader)?;
         if header.opcode == Opcode::Noop as u8 {
             break;
         }
-        let flags = reader.read_u32::<BigEndian>()?;
-        let key_length = header.key_length;
-        let value_length = header.total_body_length - u32::from(key_length) - u32::from(header.extras_length);
-        let mut key_buffer = vec![0; key_length as usize];
-        reader.read_exact(key_buffer.as_mut_slice())?;
-        let key = String::from_utf8(key_buffer)?;
-        let mut value_buffer = vec![0; value_length as usize];
-        reader.read_exact(value_buffer.as_mut_slice())?;
+        let flags = Cursor::new(extras).read_u32::<BigEndian>()?;
+        let key = String::from_utf8(key)?;
         result.insert(
             key,
-            FromMemcacheValueExt::from_memcache_value(value_buffer, flags, Some(header.cas))?,
+            FromMemcacheValueExt::from_memcache_value(value, flags, Some(header.cas))?,
         );
     }
-    return Ok(result);
+    Ok(result)
 }
 
 pub fn parse_delete_response<R: io::Read>(reader: &mut R) -> Result<bool, MemcacheError> {
-    let header = PacketHeader::read(reader)?;
-    if header.total_body_length != 0 {
-        reader.read_exact(vec![0; header.total_body_length as usize].as_mut_slice())?;
+    match parse_response(reader) {
+        Ok(_) => Ok(true),
+        Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
+        Err(e) => Err(e)
     }
-    if header.vbucket_id_or_status == ResponseStatus::KeyNotFound as u16 {
-        return Ok(false);
-    } else if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-        return Err(MemcacheError::from(header.vbucket_id_or_status));
-    }
-    return Ok(true);
 }
 
 pub fn parse_counter_response<R: io::Read>(reader: &mut R) -> Result<u64, MemcacheError> {
-    let header = PacketHeader::read(reader)?;
-    if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-        return Err(MemcacheError::from(header.vbucket_id_or_status));
-    }
-    return Ok(reader.read_u64::<BigEndian>()?);
+    let Response { extras, .. } = parse_response(reader)?;
+    Ok(Cursor::new(extras).read_u64::<BigEndian>()?)
 }
 
 pub fn parse_touch_response<R: io::Read>(reader: &mut R) -> Result<bool, MemcacheError> {
-    let header = PacketHeader::read(reader)?;
-    if header.total_body_length != 0 {
-        reader.read_exact(vec![0; header.total_body_length as usize].as_mut_slice())?;
+    match parse_response(reader) {
+        Ok(_) => Ok(true),
+        Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
+        Err(e) => Err(e)
     }
-    if header.vbucket_id_or_status == ResponseStatus::KeyNotFound as u16 {
-        return Ok(false);
-    } else if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-        return Err(MemcacheError::from(header.vbucket_id_or_status));
-    }
-    return Ok(true);
 }
 
 pub fn parse_stats_response<R: io::Read>(reader: &mut R) -> Result<HashMap<String, String>, MemcacheError> {
     let mut result = HashMap::new();
     loop {
-        let header = PacketHeader::read(reader)?;
-        if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-            return Err(MemcacheError::from(header.vbucket_id_or_status));
-        }
-        let key_length = header.key_length;
-        let value_length = header.total_body_length - u32::from(key_length) - u32::from(header.extras_length);
-        let mut key_buffer = vec![0; key_length as usize];
-        reader.read_exact(key_buffer.as_mut_slice())?;
-        let key = String::from_utf8(key_buffer)?;
-        let mut value_buffer = vec![0; value_length as usize];
-        reader.read_exact(value_buffer.as_mut_slice())?;
-        let value = String::from_utf8(value_buffer)?;
-        if key == "" && value == "" {
+        let Response { header, key, value, .. } = parse_response(reader)?;
+        let key = String::from_utf8(key)?;
+        let value = String::from_utf8(value)?;
+        if key.is_empty() && value.is_empty() {
             break;
         }
         result.insert(key, value);
     }
-    return Ok(result);
+    Ok(result)
 }
 
 pub fn parse_start_auth_response<R: io::Read>(reader: &mut R) -> Result<bool, MemcacheError> {
-    let header = PacketHeader::read(reader)?;
-    if header.total_body_length != 0 {
-        reader.read_exact(vec![0; header.total_body_length as usize].as_mut_slice())?;
-    }
-    if header.vbucket_id_or_status != ResponseStatus::NoError as u16 {
-        return Err(MemcacheError::from(header.vbucket_id_or_status));
-    }
-    return Ok(true);
+    parse_response(reader).map(|_| true)
 }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -25,16 +25,6 @@ pub enum Protocol {
     Binary(BinaryProtocol),
 }
 
-#[allow(dead_code)]
-pub enum ResponseStatus {
-    NoError = 0x00,
-    KeyNotFound = 0x01,
-    KeyExists = 0x02,
-    ValueTooLarge = 0x03,
-    InvalidArguments = 0x04,
-    AuthenticationRequired = 0x20,
-}
-
 #[enum_dispatch(Protocol)]
 pub trait ProtocolTrait {
     fn auth(&mut self, username: &str, password: &str) -> Result<(), MemcacheError>;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -2,6 +2,7 @@ mod ascii;
 mod binary;
 mod binary_packet;
 
+use crate::error::ClientError;
 use client::Stats;
 use enum_dispatch::enum_dispatch;
 use error::MemcacheError;
@@ -10,22 +11,12 @@ pub(crate) use protocol::binary::BinaryProtocol;
 use std::collections::HashMap;
 use stream::Stream;
 use value::{FromMemcacheValueExt, ToMemcacheValue};
-use crate::error::ClientError;
 
 pub(crate) fn check_key_len(key: &str) -> Result<(), MemcacheError> {
     if key.len() > 250 {
         Err(ClientError::KeyTooLong)?
     }
     Ok(())
-}
-
-pub enum ResponseStatus {
-    NoError = 0x00,
-    KeyNotFound = 0x01,
-    KeyExists = 0x02,
-    ValueTooLarge = 0x03,
-    InvalidArguments = 0x04,
-    AuthenticationRequired = 0x20,
 }
 
 #[enum_dispatch]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -10,6 +10,23 @@ pub(crate) use protocol::binary::BinaryProtocol;
 use std::collections::HashMap;
 use stream::Stream;
 use value::{FromMemcacheValueExt, ToMemcacheValue};
+use crate::error::ClientError;
+
+pub(crate) fn check_key_len(key: &str) -> Result<(), MemcacheError> {
+    if key.len() > 250 {
+        Err(ClientError::KeyTooLong)?
+    }
+    Ok(())
+}
+
+pub enum ResponseStatus {
+    NoError = 0x00,
+    KeyNotFound = 0x01,
+    KeyExists = 0x02,
+    ValueTooLarge = 0x03,
+    InvalidArguments = 0x04,
+    AuthenticationRequired = 0x20,
+}
 
 #[enum_dispatch]
 pub enum Protocol {

--- a/src/value.rs
+++ b/src/value.rs
@@ -159,10 +159,7 @@ macro_rules! impl_from_memcache_value_for_number {
         impl FromMemcacheValue for $ty {
             fn from_memcache_value(value: Vec<u8>, _: u32) -> MemcacheValue<Self> {
                 let s: String = FromMemcacheValue::from_memcache_value(value, 0)?;
-                match Self::from_str(s.as_str()) {
-                    Ok(v) => return Ok(v),
-                    Err(e) => Err(MemcacheError::from(e)),
-                }
+                Ok(Self::from_str(s.as_str())?)
             }
         }
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -59,35 +59,35 @@ fn test() {
 
 #[test]
 fn issue74() {
-    let mut client = memcache::Client::connect("memcache://localhost:12346?tcp_nodelay=true").unwrap();
+    use memcache::{Client, CommandError, MemcacheError};
+    let mut client = Client::connect("memcache://localhost:12346?tcp_nodelay=true").unwrap();
     client.delete("issue74").unwrap();
     client.add("issue74", 1, 0).unwrap();
 
     match client.add("issue74", 1, 0) {
         Ok(_) => panic!("Should got an error!"),
         Err(e) => match e {
-            memcache::MemcacheError::ServerError(e) => assert!(e == 2),
+            MemcacheError::CommandError(e) => assert!(e == CommandError::KeyExists),
             _ => panic!("Unexpected error!"),
-        }
+        },
     }
 
     match client.add("issue74", 1, 0) {
         Ok(_) => panic!("Should got an error!"),
         Err(e) => match e {
-            memcache::MemcacheError::ServerError(e) => assert!(e == 2),
+            MemcacheError::CommandError(e) => assert!(e == CommandError::KeyExists),
             _ => panic!("Unexpected error!"),
-        }
+        },
     }
 
     match client.add("issue74", 1, 0) {
         Ok(_) => panic!("Should got an error!"),
         Err(e) => match e {
-            memcache::MemcacheError::ServerError(e) => assert!(e == 2),
+            MemcacheError::CommandError(e) => assert!(e == CommandError::KeyExists),
             _ => panic!("Unexpected error!"),
-        }
+        },
     }
 }
-
 
 #[test]
 fn udp_test() {


### PR DESCRIPTION
Fixes #79 

I may have gone a bit overboard refactoring the binary protocol. Sorry about that!

The issue with returning same errors in both ASCII and binary protocol is that the format of errors is different. We should instead document that the errors returned by both the protocols may be different but guarantee that the same error is returned in the future versions too for compatibility.