### PR TITLE
Fix regression added by upgrading url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ tls = ["openssl"]
 
 [dependencies]
 byteorder = "1"
-url = "^2.1"
+url = "2.1.1"
 rand = "0.7"
 enum_dispatch = "0.2"
 openssl = { version = "^0.10", optional = true }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -3,8 +3,6 @@ use std::net::TcpStream;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::time::Duration;
-#[cfg(unix)]
-use url::Host;
 use url::Url;
 
 use error::MemcacheError;
@@ -138,7 +136,7 @@ impl Transport {
 
         #[cfg(unix)]
         {
-            if url.host() == Some(Host::Domain("")) && url.port() == None {
+            if url.host().is_none() && url.port() == None {
                 return Ok(Transport::Unix);
             }
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -206,3 +206,18 @@ impl Connection {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    #[test]
+    fn test_transport_url() {
+        use super::Transport;
+        use url::Url;
+        match Transport::from_url(&Url::parse("memcache:///tmp/memcached.sock").unwrap()).unwrap() {
+            Transport::Unix => (),
+            _ => assert!(false, "transport is not unix")
+        }
+    }
+}
+


### PR DESCRIPTION
Upgrading url to 2.1 [(commit)](https://github.com/aisk/rust-memcache/commit/39d0609d7f65ea6c822e60f3855f628429ab8aae) added a regression. This PR fixes it. v0.14.0 is also affected.