### PR TITLE
:bug: avoid short writes when writing out values

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -25,7 +25,7 @@ impl<'a, W: Write> ToMemcacheValue<W> for &'a [u8] {
     }
 
     fn write_to(&self, stream: &mut W) -> io::Result<()> {
-        match stream.write(self) {
+        match stream.write_all(self) {
             Ok(_) => Ok(()),
             Err(e) => Err(e),
         }
@@ -56,7 +56,7 @@ impl<W: Write> ToMemcacheValue<W> for String {
     }
 
     fn write_to(&self, stream: &mut W) -> io::Result<()> {
-        match stream.write(self.as_bytes()) {
+        match stream.write_all(self.as_bytes()) {
             Ok(_) => Ok(()),
             Err(e) => Err(e),
         }
@@ -73,7 +73,7 @@ impl<'a, W: Write> ToMemcacheValue<W> for &'a str {
     }
 
     fn write_to(&self, stream: &mut W) -> io::Result<()> {
-        match stream.write(self.as_bytes()) {
+        match stream.write_all(self.as_bytes()) {
             Ok(_) => Ok(()),
             Err(e) => Err(e),
         }
@@ -92,7 +92,7 @@ macro_rules! impl_to_memcache_value_for_number {
             }
 
             fn write_to(&self, stream: &mut W) -> io::Result<()> {
-                match stream.write(self.to_string().as_bytes()) {
+                match stream.write_all(self.to_string().as_bytes()) {
                     Ok(_) => Ok(()),
                     Err(e) => Err(e),
                 }


### PR DESCRIPTION
The previous code was not using write_all when writing out values to
the given stream. As a result, it was possible to incompletely write
out the value. Such a sort write would typically result in the client
blocking indefinitely as it tried to read a server response while the
server was still waiting for data.

We encountered this when moving to the TLS transport since the
underlying openssl library uses a 16KB buffer by default and some of
our value bodies were over 16KB.

Signed-off-by: Steven Danna <steve@chef.io>