### PR TITLE
Use custom BufReader impl for Ascii protocol

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -103,7 +103,7 @@ impl Client {
     pub fn set_read_timeout(&self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
         for conn in self.connections.iter() {
             match *conn.get_ref() {
-                Protocol::Ascii(ref mut protocol) => protocol.reader.get_mut().set_read_timeout(timeout)?,
+                Protocol::Ascii(ref mut protocol) => protocol.stream().set_read_timeout(timeout)?,
                 Protocol::Binary(ref mut protocol) => protocol.stream.set_read_timeout(timeout)?,
             }
         }
@@ -121,7 +121,7 @@ impl Client {
     pub fn set_write_timeout(&self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
         for conn in self.connections.iter() {
             match *conn.get_ref() {
-                Protocol::Ascii(ref mut protocol) => protocol.reader.get_mut().set_read_timeout(timeout)?,
+                Protocol::Ascii(ref mut protocol) => protocol.stream().set_read_timeout(timeout)?,
                 Protocol::Binary(ref mut protocol) => protocol.stream.set_write_timeout(timeout)?,
             }
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,4 +1,3 @@
-use std::io::BufReader;
 use std::net::TcpStream;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
@@ -205,9 +204,7 @@ impl Connection {
         };
 
         let protocol = if is_ascii {
-            Protocol::Ascii(AsciiProtocol {
-                reader: BufReader::new(stream),
-            })
+            Protocol::Ascii(AsciiProtocol::new(stream))
         } else {
             Protocol::Binary(BinaryProtocol { stream: stream })
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,13 +73,13 @@ pub enum CommandError {
 }
 
 impl MemcacheError {
-    pub(crate) fn try_from(s: String) -> Result<String, MemcacheError> {
+    pub(crate) fn try_from(s: &str) -> Result<&str, MemcacheError> {
         if s == "ERROR\r\n" {
             Err(CommandError::InvalidCommand)?
         } else if s.starts_with("CLIENT_ERROR") {
-            Err(ClientError::from(s))?
+            Err(ClientError::from(String::from(s)))?
         } else if s.starts_with("SERVER_ERROR") {
-            Err(ServerError::from(s))?
+            Err(ServerError::from(String::from(s)))?
         } else if s == "NOT_FOUND\r\n" {
             Err(CommandError::KeyNotFound)?
         } else if s == "EXISTS\r\n" {
@@ -147,6 +147,7 @@ pub enum ParseError {
     Int(num::ParseIntError),
     Float(num::ParseFloatError),
     String(string::FromUtf8Error),
+    Str(std::str::Utf8Error),
     Url(url::ParseError),
 }
 
@@ -157,6 +158,7 @@ impl error::Error for ParseError {
             ParseError::Int(ref e) => e.source(),
             ParseError::Float(ref e) => e.source(),
             ParseError::String(ref e) => e.source(),
+            ParseError::Str(ref e) => e.source(),
             ParseError::Url(ref e) => e.source(),
         }
     }
@@ -169,6 +171,7 @@ impl fmt::Display for ParseError {
             ParseError::Int(ref e) => e.fmt(f),
             ParseError::Float(ref e) => e.fmt(f),
             ParseError::String(ref e) => e.fmt(f),
+            ParseError::Str(ref e) => e.fmt(f),
             ParseError::Url(ref e) => e.fmt(f),
         }
     }
@@ -185,6 +188,13 @@ impl From<string::FromUtf8Error> for MemcacheError {
         ParseError::String(err).into()
     }
 }
+
+impl From<std::str::Utf8Error> for MemcacheError {
+    fn from(err: std::str::Utf8Error) -> MemcacheError {
+        ParseError::Str(err).into()
+    }
+}
+
 impl From<num::ParseIntError> for MemcacheError {
     fn from(err: num::ParseIntError) -> MemcacheError {
         ParseError::Int(err).into()

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{Read, Write};
 
 use super::check_key_len;
 use client::Stats;
@@ -41,11 +41,84 @@ impl fmt::Display for StoreCommand {
         }
     }
 }
+
+struct MyBufReader<C> {
+    inner: C,
+    filled: usize,
+    buf: Box<[u8]>,
+}
+
+fn get_line(buf: &[u8]) -> Option<usize> {
+    for (i, r) in buf.iter().enumerate() {
+        if *r == b'\r' {
+            if buf.get(i + 1) == Some(&b'\n') {
+                return Some(i + 2);
+            }
+        }
+    }
+    None
+}
+
+impl<C: Read> MyBufReader<C> {
+    fn with_capacity(capacity: usize, inner: C) -> Self {
+        let mut buf = Vec::with_capacity(capacity);
+        unsafe { buf.set_len(capacity) };
+        Self {
+            inner,
+            filled: 0,
+            buf: buf.into_boxed_slice(),
+        }
+    }
+
+    fn get_mut(&mut self) -> &mut C {
+        &mut self.inner
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
+        buf.copy_from_slice(&self.buf[..self.filled]);
+        self.filled = 0;
+        self.inner.read_exact(&mut buf[self.filled..])
+    }
+
+    fn read_line(&mut self) -> std::io::Result<&[u8]> {
+        // check if the buf already has a new line
+        if let Some(n) = get_line(&self.buf[..self.filled]) {
+            return Ok(&self.buf[..n]);
+        }
+        loop {
+            let (filled, buf) = self.buf.split_at_mut(self.filled);
+            let filled = filled.len();
+            let read = self.inner.read(&mut buf[..])?;
+            if read == 0 {
+                // TODO: change to error
+                panic!("{:?} {:?} line too long", filled, buf.len());
+            }
+            self.filled += read;
+            if let Some(n) = get_line(&buf[..read]) {
+                return Ok(&self.buf[..filled + n]);
+            }
+        }
+    }
+
+    fn consume(&mut self, amount: usize) {
+        let amount = std::cmp::min(self.filled, amount);
+        self.buf.copy_within(amount..self.filled, 0);
+        self.filled -= amount;
+    }
+}
+
 pub struct AsciiProtocol<C: Read + Write + Sized> {
-    pub reader: BufReader<C>,
+    pub reader: MyBufReader<C>,
 }
 
 impl AsciiProtocol<Stream> {
+
+    pub(crate) fn new(stream: Stream) -> Self {
+        Self {
+            reader: MyBufReader::with_capacity(2*1024, stream)
+        }
+    }
+
     pub(super) fn auth(&mut self, username: &str, password: &str) -> Result<(), MemcacheError> {
         return self.set("auth", format!("{} {}", username, password), 0);
     }

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -42,10 +42,10 @@ impl fmt::Display for StoreCommand {
     }
 }
 
-struct MyBufReader<C> {
+struct CappedLineReader<C> {
     inner: C,
     filled: usize,
-    buf: Box<[u8]>,
+    buf: [u8; 2048],
 }
 
 fn get_line(buf: &[u8]) -> Option<usize> {
@@ -59,43 +59,58 @@ fn get_line(buf: &[u8]) -> Option<usize> {
     None
 }
 
-impl<C: Read> MyBufReader<C> {
-    fn with_capacity(capacity: usize, inner: C) -> Self {
-        let mut buf = Vec::with_capacity(capacity);
-        unsafe { buf.set_len(capacity) };
+impl<C: Read> CappedLineReader<C> {
+    fn new(inner: C) -> Self {
         Self {
             inner,
             filled: 0,
-            buf: buf.into_boxed_slice(),
+            buf: [0x0; 2048]
         }
     }
 
-    fn get_mut(&mut self) -> &mut C {
+    pub(crate) fn get_mut(&mut self) -> &mut C {
         &mut self.inner
     }
 
-    fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
-        buf.copy_from_slice(&self.buf[..self.filled]);
-        self.filled = 0;
-        self.inner.read_exact(&mut buf[self.filled..])
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), MemcacheError> {
+        let min = std::cmp::min(buf.len(), self.filled);
+        let (to_fill, rest) = buf.split_at_mut(min);
+        to_fill.copy_from_slice(&self.buf[..min]);
+        self.consume(min);
+        if rest.len() != 0 {
+            self.inner.read_exact(&mut rest[..])?;
+        }
+        Ok(())
     }
 
-    fn read_line(&mut self) -> std::io::Result<&[u8]> {
+    /// Try to read a CRLF terminated line from the underlying reader.
+    /// The length of the line is expected to be <= the length of the
+    /// internal buffer, suited for reading headers or short responses.
+    fn read_line<T, F>(&mut self, mut cb: F) -> Result<T, MemcacheError>
+    where
+        F: FnMut(&str) -> Result<T, MemcacheError>,
+    {
         // check if the buf already has a new line
         if let Some(n) = get_line(&self.buf[..self.filled]) {
-            return Ok(&self.buf[..n]);
+            let result = cb(std::str::from_utf8(&self.buf[..n])?);
+            self.consume(n);
+            return result;
         }
         loop {
             let (filled, buf) = self.buf.split_at_mut(self.filled);
+            if buf.len() == 0 {
+                return Err(ClientError::Error(Cow::Borrowed("Ascii protocol response too long")))?;
+            }
             let filled = filled.len();
             let read = self.inner.read(&mut buf[..])?;
             if read == 0 {
-                // TODO: change to error
-                panic!("{:?} {:?} line too long", filled, buf.len());
+                return Err(ClientError::Error(Cow::Borrowed("Ascii protocol no line found")))?;
             }
             self.filled += read;
             if let Some(n) = get_line(&buf[..read]) {
-                return Ok(&self.buf[..filled + n]);
+                let result = cb(std::str::from_utf8(&self.buf[..filled + n])?);
+                self.consume(n);
+                return result;
             }
         }
     }
@@ -108,15 +123,18 @@ impl<C: Read> MyBufReader<C> {
 }
 
 pub struct AsciiProtocol<C: Read + Write + Sized> {
-    pub reader: MyBufReader<C>,
+    reader: CappedLineReader<C>,
 }
 
 impl AsciiProtocol<Stream> {
-
     pub(crate) fn new(stream: Stream) -> Self {
         Self {
-            reader: MyBufReader::with_capacity(2*1024, stream)
+            reader: CappedLineReader::new(stream),
         }
+    }
+
+    pub(crate) fn stream(&mut self) -> &mut Stream {
+        self.reader.get_mut()
     }
 
     pub(super) fn auth(&mut self, username: &str, password: &str) -> Result<(), MemcacheError> {
@@ -172,48 +190,40 @@ impl AsciiProtocol<Stream> {
             return Ok(true);
         }
 
-        let mut s = String::new();
-        self.reader.read_line(&mut s)?;
-        match MemcacheError::try_from(s) {
-            Ok(s) if s == "STORED\r\n" => Ok(true),
-            Ok(s) if s == "NOT_STORED\r\n" => Ok(false),
-            Ok(s) => {
-                if s == "EXISTS\r\n" {
-                    Err(CommandError::KeyExists)?
-                } else if s == "NOT_FOUND\r\n" {
-                    Err(CommandError::KeyNotFound)?
-                } else {
-                    Err(ServerError::BadResponse(Cow::Owned(s)))?
-                }
+        self.reader.read_line(|response| {
+            let response = MemcacheError::try_from(response)?;
+            match response {
+                "STORED\r\n" => Ok(true),
+                "NOT_STORED\r\n" => Ok(false),
+                "EXISTS\r\n" => Err(CommandError::KeyExists)?,
+                "NOT_FOUND\r\n" => Err(CommandError::KeyNotFound)?,
+                response => Err(ServerError::BadResponse(Cow::Owned(response.into())))?,
             }
-            Err(e) => Err(e),
-        }
+        })
     }
 
     pub(super) fn version(&mut self) -> Result<String, MemcacheError> {
         self.reader.get_mut().write(b"version\r\n")?;
         self.reader.get_mut().flush()?;
-        let mut s = String::new();
-        self.reader.read_line(&mut s)?;
-        let s = MemcacheError::try_from(s)?;
-        if !s.starts_with("VERSION") {
-            return Err(ServerError::BadResponse(Cow::Owned(s)))?;
-        }
-        let s = s.trim_start_matches("VERSION ");
-        let s = s.trim_end_matches("\r\n");
-
-        return Ok(s.to_string());
+        self.reader.read_line(|response| {
+            let response = MemcacheError::try_from(response)?;
+            if !response.starts_with("VERSION") {
+                Err(ServerError::BadResponse(Cow::Owned(response.into())))?
+            }
+            let version = response.trim_start_matches("VERSION ").trim_end_matches("\r\n");
+            Ok(version.to_string())
+        })
     }
 
     fn parse_ok_response(&mut self) -> Result<(), MemcacheError> {
-        let mut s = String::new();
-        self.reader.read_line(&mut s)?;
-        let s = MemcacheError::try_from(s)?;
-        if s == "OK\r\n" {
-            Ok(())
-        } else {
-            Err(ServerError::BadResponse(Cow::Owned(s)))?
-        }
+        self.reader.read_line(|response| {
+            let response = MemcacheError::try_from(response)?;
+            if response == "OK\r\n" {
+                Ok(())
+            } else {
+                Err(ServerError::BadResponse(Cow::Owned(response.into())))?
+            }
+        })
     }
 
     pub(super) fn flush(&mut self) -> Result<(), MemcacheError> {
@@ -249,39 +259,46 @@ impl AsciiProtocol<Stream> {
         &mut self,
         has_cas: bool,
     ) -> Result<Option<(String, V)>, MemcacheError> {
-        let mut buf = String::new();
-        self.reader.read_line(&mut buf)?;
-        buf = MemcacheError::try_from(buf)?;
-        if buf == END {
-            return Ok(None);
+        let result = self.reader.read_line(|buf| {
+            let buf = MemcacheError::try_from(buf)?;
+            if buf == END {
+                return Ok(None);
+            }
+            if !buf.starts_with("VALUE") {
+                return Err(ServerError::BadResponse(Cow::Owned(buf.into())))?;
+            }
+            let mut header = buf.trim_end_matches("\r\n").split(" ");
+            let mut next_or_err = || {
+                header
+                    .next()
+                    .ok_or_else(|| ServerError::BadResponse(Cow::Owned(buf.into())))
+            };
+            let _ = next_or_err()?;
+            let key = next_or_err()?;
+            let flags: u32 = next_or_err()?.parse()?;
+            let length: usize = next_or_err()?.parse()?;
+            let cas: Option<u64> = if has_cas { Some(next_or_err()?.parse()?) } else { None };
+            if header.next().is_some() {
+                return Err(ServerError::BadResponse(Cow::Owned(buf.into())))?;
+            }
+            Ok(Some((key.to_string(), flags, length, cas)))
+        })?;
+        match result {
+            Some((key, flags, length, cas)) => {
+                let mut value = vec![0u8; length + 2];
+                self.reader.read_exact(value.as_mut_slice())?;
+                if &value[length..] != b"\r\n" {
+                    return Err(ServerError::BadResponse(Cow::Owned(String::from_utf8(value)?)))?;
+                }
+                // remove the trailing \r\n
+                value.pop();
+                value.pop();
+                value.shrink_to_fit();
+                let value = FromMemcacheValueExt::from_memcache_value(value, flags, cas)?;
+                Ok(Some((key.to_string(), value)))
+            }
+            None => Ok(None),
         }
-        if !buf.starts_with("VALUE") {
-            return Err(ServerError::BadResponse(Cow::Owned(buf.clone())))?;
-        }
-        let mut header = buf.trim_end_matches("\r\n").split(" ");
-        let mut next_or_err = || {
-            header
-                .next()
-                .ok_or_else(|| ServerError::BadResponse(Cow::Owned(buf.clone())))
-        };
-        let _ = next_or_err()?;
-        let key = next_or_err()?;
-        let flags = next_or_err()?.parse()?;
-        let length: usize = next_or_err()?.parse()?;
-        let cas = if has_cas { Some(next_or_err()?.parse()?) } else { None };
-        if header.next().is_some() {
-            return Err(ServerError::BadResponse(Cow::Owned(buf.clone())))?;
-        }
-        let mut value = vec![0u8; length + 2];
-        self.reader.read_exact(value.as_mut_slice())?;
-        if &value[length..] != b"\r\n" {
-            return Err(ServerError::BadResponse(Cow::Owned(String::from_utf8(value)?)))?;
-        }
-        // remove the trailing \r\n
-        value.pop(); value.pop();
-        value.shrink_to_fit();
-        let value = FromMemcacheValueExt::from_memcache_value(value, flags, cas)?;
-        Ok(Some((key.to_string(), value)))
     }
 
     pub(super) fn gets<V: FromMemcacheValueExt>(&mut self, keys: &[&str]) -> Result<HashMap<String, V>, MemcacheError> {
@@ -380,26 +397,25 @@ impl AsciiProtocol<Stream> {
         check_key_len(key)?;
         write!(self.reader.get_mut(), "delete {}\r\n", key)?;
         self.reader.get_mut().flush()?;
-        let mut s = String::new();
-        self.reader.read_line(&mut s)?;
-        match MemcacheError::try_from(s) {
-            Ok(s) => {
-                if s == "DELETED\r\n" {
-                    Ok(true)
-                } else {
-                    Err(ServerError::BadResponse(Cow::Owned(s)))?
+        self.reader
+            .read_line(|response| match MemcacheError::try_from(response) {
+                Ok(s) => {
+                    if s == "DELETED\r\n" {
+                        Ok(true)
+                    } else {
+                        Err(ServerError::BadResponse(Cow::Owned(s.into())).into())
+                    }
                 }
-            }
-            Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
-            Err(e) => Err(e),
-        }
+                Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
+                Err(e) => Err(e),
+            })
     }
 
     fn parse_u64_response(&mut self) -> Result<u64, MemcacheError> {
-        let mut s = String::new();
-        self.reader.read_line(&mut s)?;
-        let s = MemcacheError::try_from(s)?;
-        Ok(s.trim_end_matches("\r\n").parse::<u64>()?)
+        self.reader.read_line(|response| {
+            let s = MemcacheError::try_from(response)?;
+            Ok(s.trim_end_matches("\r\n").parse::<u64>()?)
+        })
     }
 
     pub(super) fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
@@ -418,47 +434,53 @@ impl AsciiProtocol<Stream> {
         check_key_len(key)?;
         write!(self.reader.get_mut(), "touch {} {}\r\n", key, expiration)?;
         self.reader.get_mut().flush()?;
-        let mut s = String::new();
-        self.reader.read_line(&mut s)?;
-        match MemcacheError::try_from(s) {
-            Ok(s) => {
-                if s == "TOUCHED\r\n" {
-                    Ok(true)
-                } else {
-                    Err(ServerError::BadResponse(Cow::Owned(s)))?
+        self.reader
+            .read_line(|response| match MemcacheError::try_from(response) {
+                Ok(s) => {
+                    if s == "TOUCHED\r\n" {
+                        Ok(true)
+                    } else {
+                        Err(ServerError::BadResponse(Cow::Owned(s.into())).into())
+                    }
                 }
-            }
-            Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
-            Err(e) => Err(e),
-        }
+                Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
+                Err(e) => Err(e),
+            })
     }
 
     pub(super) fn stats(&mut self) -> Result<Stats, MemcacheError> {
         self.reader.get_mut().write(b"stats\r\n")?;
         self.reader.get_mut().flush()?;
 
-        let mut result: Stats = HashMap::new();
-        loop {
-            let mut s = String::new();
-            self.reader.read_line(&mut s)?;
-
-            let s = MemcacheError::try_from(s)?;
-            if s == END {
-                break;
-            }
-            if !s.starts_with("STAT") {
-                return Err(ServerError::BadResponse(Cow::Owned(s)).into());
-            }
-
-            let stat: Vec<_> = s.trim_end_matches("\r\n").split(" ").collect();
-            if stat.len() < 3 {
-                return Err(ServerError::BadResponse(Cow::Owned(s)).into());
-            }
-            let key = stat[1];
-            let value = s.trim_start_matches(format!("STAT {}", key).as_str());
-            result.insert(key.into(), value.into());
+        enum Loop {
+            Break,
+            Continue,
         }
 
-        return Ok(result);
+        let mut stats: Stats = HashMap::new();
+        loop {
+            let status = self.reader.read_line(|response| {
+                if response != END {
+                    return Ok(Loop::Break);
+                }
+                let s = MemcacheError::try_from(response)?;
+                if !s.starts_with("STAT") {
+                    return Err(ServerError::BadResponse(Cow::Owned(s.into())))?;
+                }
+                let stat: Vec<_> = s.trim_end_matches("\r\n").split(" ").collect();
+                if stat.len() < 3 {
+                    return Err(ServerError::BadResponse(Cow::Owned(s.into())).into());
+                }
+                let key = stat[1];
+                let value = s.trim_start_matches(format!("STAT {}", key).as_str());
+                stats.insert(key.into(), value.into());
+
+                Ok(Loop::Continue)
+            })?;
+
+            if let Loop::Break = status {
+                break Ok(stats);
+            }
+        }
     }
 }


### PR DESCRIPTION
The new impl performs better by potentially reducing allocations. Benchmark setup here: https://github.com/letmutx/line-reader/

Benchmarks (take it with a grain of salt)
```
$ cargo +nightly bench
running 2 tests
test tests::bench_reader  ... bench:     129,350 ns/iter (+/- 1,025,945)
test tests::bench_reader2 ... bench:     135,599 ns/iter (+/- 1,225,536)
```