### PR TITLE
Pipeline Operations

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,18 @@ pub enum CommandError {
 }
 
 impl MemcacheError {
+    pub(crate) fn is_recoverable(&self) -> bool {
+        match self {
+            MemcacheError::ClientError(ref err) if err != &ClientError::KeyTooLong => false,
+            MemcacheError::ServerError(_) => false,
+            MemcacheError::IOError(_) => false,
+            MemcacheError::ParseError(_) => false,
+            #[cfg(feature = "tls")]
+            MemcacheError::OpensslError(_) => false,
+            _ => true,
+        }
+    }
+
     pub(crate) fn try_from(s: &str) -> Result<&str, MemcacheError> {
         if s == "ERROR\r\n" {
             Err(CommandError::InvalidCommand)?

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -247,10 +247,10 @@ impl AsciiProtocol<Stream> {
                         final_result = Ok(false)
                     }
                 }
-                Err(MemcacheError::CommandError(e)) => {
+                Err(e) if e.is_recoverable() => {
                     // Recoverable error. Report it after reading the rest of the responses.
                     if final_result.is_ok() {
-                        final_result = Err(MemcacheError::CommandError(e));
+                        final_result = Err(e);
                     }
                 }
                 Err(e) => return Err(e), // Unrecoverable error. Stop immediately.
@@ -512,10 +512,10 @@ impl AsciiProtocol<Stream> {
                         deleted_list.push(deleted);
                     }
                 }
-                Err(MemcacheError::CommandError(e)) => {
+                Err(e) if e.is_recoverable() => {
                     // Recoverable error. Report it after reading the rest of the responses.
                     if final_result.is_ok() {
-                        final_result = Err(MemcacheError::CommandError(e));
+                        final_result = Err(e);
                     }
                 }
                 Err(e) => return Err(e), // Unrecoverable error. Stop immediately.

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -352,7 +352,7 @@ impl AsciiProtocol<Stream> {
         }
     }
 
-    pub(super) fn get_multi<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
+    pub(super) fn gets<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
         &mut self,
         keys: I,
     ) -> Result<HashMap<String, V>, MemcacheError> {
@@ -420,7 +420,7 @@ impl AsciiProtocol<Stream> {
         self.store(StoreCommand::Set, key, value, &options).map(|_| ())
     }
 
-    pub(super) fn set_multi<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
+    pub(super) fn sets<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
         &mut self,
         entries: I,
         expiration: u32,
@@ -470,7 +470,7 @@ impl AsciiProtocol<Stream> {
             .map(|_| ())
     }
 
-    pub(super) fn delete_multi<K: AsRef<str>, I: IntoIterator<Item = K>>(
+    pub(super) fn deletes<K: AsRef<str>, I: IntoIterator<Item = K>>(
         &mut self,
         keys: I,
     ) -> Result<Vec<bool>, MemcacheError> {
@@ -518,7 +518,7 @@ impl AsciiProtocol<Stream> {
     }
 
     pub(super) fn delete(&mut self, key: &str) -> Result<bool, MemcacheError> {
-        Ok(self.delete_multi(&[key])?[0])
+        Ok(self.deletes(&[key])?[0])
     }
 
     fn parse_u64_response(&mut self) -> Result<u64, MemcacheError> {

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -95,10 +95,10 @@ impl BinaryProtocol {
         for _ in 0..sent_count {
             match binary_packet::parse_response(&mut self.stream) {
                 Ok(_) => (),
-                Err(MemcacheError::CommandError(e)) => {
+                Err(e) if e.is_recoverable() => {
                     // Recoverable error. Report it after reading the rest of the responses.
                     if final_result.is_ok() {
-                        final_result = Err(MemcacheError::CommandError(e));
+                        final_result = Err(e);
                     }
                 }
                 Err(e) => return Err(e), // Unrecoverable error. Stop immediately.
@@ -303,10 +303,10 @@ impl BinaryProtocol {
                         deleted_list.push(deleted);
                     }
                 }
-                Err(MemcacheError::CommandError(e)) => {
+                Err(e) if e.is_recoverable() => {
                     // Recoverable error. Report it after reading the rest of the responses.
                     if final_result.is_ok() {
-                        final_result = Err(MemcacheError::CommandError(e));
+                        final_result = Err(e);
                     }
                 }
                 Err(e) => return Err(e), // Unrecoverable error. Stop immediately.

--- a/src/protocol/binary.rs
+++ b/src/protocol/binary.rs
@@ -154,7 +154,7 @@ impl BinaryProtocol {
         return binary_packet::parse_get_response(&mut self.stream);
     }
 
-    pub(super) fn get_multi<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
+    pub(super) fn gets<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
         &mut self,
         keys: I,
     ) -> Result<HashMap<String, V>, MemcacheError> {
@@ -204,7 +204,7 @@ impl BinaryProtocol {
         return self.store(Opcode::Set, key, value, expiration, None);
     }
 
-    pub(super) fn set_multi<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
+    pub(super) fn sets<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
         &mut self,
         entries: I,
         expiration: u32,
@@ -263,10 +263,10 @@ impl BinaryProtocol {
     }
 
     pub(super) fn delete(&mut self, key: &str) -> Result<bool, MemcacheError> {
-        Ok(self.delete_multi(&[key])?[0])
+        Ok(self.deletes(&[key])?[0])
     }
 
-    pub(super) fn delete_multi<K: AsRef<str>, I: IntoIterator<Item = K>>(
+    pub(super) fn deletes<K: AsRef<str>, I: IntoIterator<Item = K>>(
         &mut self,
         keys: I,
     ) -> Result<Vec<bool>, MemcacheError> {

--- a/src/protocol/binary_packet.rs
+++ b/src/protocol/binary_packet.rs
@@ -8,6 +8,7 @@ use value::FromMemcacheValueExt;
 const OK_STATUS: u16 = 0x0;
 
 #[allow(dead_code)]
+#[derive(Copy, Clone)]
 pub enum Opcode {
     Get = 0x00,
     Set = 0x01,

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -34,6 +34,11 @@ pub trait ProtocolTrait {
     fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError>;
     fn gets<V: FromMemcacheValueExt>(&mut self, keys: &[&str]) -> Result<HashMap<String, V>, MemcacheError>;
     fn set<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V, expiration: u32) -> Result<(), MemcacheError>;
+    fn sets<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
+        &mut self,
+        entries: I,
+        expiration: u32,
+    ) -> Result<(), MemcacheError>;
     fn cas<V: ToMemcacheValue<Stream>>(
         &mut self,
         key: &str,
@@ -51,6 +56,7 @@ pub trait ProtocolTrait {
     fn append<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn delete(&mut self, key: &str) -> Result<bool, MemcacheError>;
+    fn deletes<K: AsRef<str>, I: IntoIterator<Item = K>>(&mut self, keys: I) -> Result<Vec<bool>, MemcacheError>;
     fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn touch(&mut self, key: &str, expiration: u32) -> Result<bool, MemcacheError>;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -32,12 +32,12 @@ pub trait ProtocolTrait {
     fn flush(&mut self) -> Result<(), MemcacheError>;
     fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError>;
     fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError>;
-    fn get_multi<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
+    fn gets<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
         &mut self,
         keys: I,
     ) -> Result<HashMap<String, V>, MemcacheError>;
     fn set<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V, expiration: u32) -> Result<(), MemcacheError>;
-    fn set_multi<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
+    fn sets<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
         &mut self,
         entries: I,
         expiration: u32,
@@ -59,7 +59,7 @@ pub trait ProtocolTrait {
     fn append<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn delete(&mut self, key: &str) -> Result<bool, MemcacheError>;
-    fn delete_multi<K: AsRef<str>, I: IntoIterator<Item = K>>(&mut self, keys: I) -> Result<Vec<bool>, MemcacheError>;
+    fn deletes<K: AsRef<str>, I: IntoIterator<Item = K>>(&mut self, keys: I) -> Result<Vec<bool>, MemcacheError>;
     fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn touch(&mut self, key: &str, expiration: u32) -> Result<bool, MemcacheError>;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -32,10 +32,8 @@ pub trait ProtocolTrait {
     fn flush(&mut self) -> Result<(), MemcacheError>;
     fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError>;
     fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError>;
-    fn gets<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
-        &mut self,
-        keys: I,
-    ) -> Result<HashMap<String, V>, MemcacheError>;
+    fn gets<V: FromMemcacheValueExt, K: AsRef<str>>(&mut self, keys: &[K])
+        -> Result<HashMap<String, V>, MemcacheError>;
     fn set<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V, expiration: u32) -> Result<(), MemcacheError>;
     fn sets<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
         &mut self,
@@ -59,7 +57,7 @@ pub trait ProtocolTrait {
     fn append<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn delete(&mut self, key: &str) -> Result<bool, MemcacheError>;
-    fn deletes<K: AsRef<str>, I: IntoIterator<Item = K>>(&mut self, keys: I) -> Result<Vec<bool>, MemcacheError>;
+    fn deletes<K: AsRef<str>>(&mut self, keys: &[K]) -> Result<Vec<bool>, MemcacheError>;
     fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn touch(&mut self, key: &str, expiration: u32) -> Result<bool, MemcacheError>;

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -32,9 +32,12 @@ pub trait ProtocolTrait {
     fn flush(&mut self) -> Result<(), MemcacheError>;
     fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError>;
     fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError>;
-    fn gets<V: FromMemcacheValueExt>(&mut self, keys: &[&str]) -> Result<HashMap<String, V>, MemcacheError>;
+    fn get_multi<V: FromMemcacheValueExt, K: AsRef<str>, I: IntoIterator<Item = K>>(
+        &mut self,
+        keys: I,
+    ) -> Result<HashMap<String, V>, MemcacheError>;
     fn set<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V, expiration: u32) -> Result<(), MemcacheError>;
-    fn sets<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
+    fn set_multi<V: ToMemcacheValue<Stream>, K: AsRef<str>, I: IntoIterator<Item = (K, V)>>(
         &mut self,
         entries: I,
         expiration: u32,
@@ -56,7 +59,7 @@ pub trait ProtocolTrait {
     fn append<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError>;
     fn delete(&mut self, key: &str) -> Result<bool, MemcacheError>;
-    fn deletes<K: AsRef<str>, I: IntoIterator<Item = K>>(&mut self, keys: I) -> Result<Vec<bool>, MemcacheError>;
+    fn delete_multi<K: AsRef<str>, I: IntoIterator<Item = K>>(&mut self, keys: I) -> Result<Vec<bool>, MemcacheError>;
     fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError>;
     fn touch(&mut self, key: &str, expiration: u32) -> Result<bool, MemcacheError>;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -59,10 +59,9 @@ fn test() {
             batch.insert(key, "xxx".to_string());
         }
     }
-    client.sets(batch, 0).unwrap();
+    client.set_multi(batch, 0).unwrap();
 
-    let keys_strs: Vec<&str> = keys.iter().map(String::as_str).collect();
-    let all_at_once: HashMap<String, String> = client.gets(&keys_strs).unwrap();
+    let all_at_once: HashMap<String, String> = client.get_multi(&keys).unwrap();
     assert_eq!(1000, all_at_once.len());
 
     for key in keys.iter() {
@@ -71,8 +70,8 @@ fn test() {
         assert_eq!(all_at_once[key], "xxx");
     }
 
-    client.deletes(&keys_strs).unwrap();
-    let all_at_once: HashMap<String, String> = client.gets(&keys_strs).unwrap();
+    client.delete_multi(&keys).unwrap();
+    let all_at_once: HashMap<String, String> = client.get_multi(&keys).unwrap();
     assert_eq!(0, all_at_once.len());
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -59,9 +59,9 @@ fn test() {
             batch.insert(key, "xxx".to_string());
         }
     }
-    client.set_multi(batch, 0).unwrap();
+    client.sets(batch, 0).unwrap();
 
-    let all_at_once: HashMap<String, String> = client.get_multi(&keys).unwrap();
+    let all_at_once: HashMap<String, String> = client.gets(&keys).unwrap();
     assert_eq!(1000, all_at_once.len());
 
     for key in keys.iter() {
@@ -70,8 +70,8 @@ fn test() {
         assert_eq!(all_at_once[key], "xxx");
     }
 
-    client.delete_multi(&keys).unwrap();
-    let all_at_once: HashMap<String, String> = client.get_multi(&keys).unwrap();
+    client.deletes(&keys).unwrap();
+    let all_at_once: HashMap<String, String> = client.gets(&keys).unwrap();
     assert_eq!(0, all_at_once.len());
 }
 


### PR DESCRIPTION
This PR adds set_multi() and delete_multi() methods, which use pipelining to reduce the number of server round trips when setting or deleting multiple keys. The new methods accept generic collection arguments. For example, set_multi() accepts a HashMap or Vec of many types of strings.

This PR also adds get_multi() and changes client.gets() to use get_multi(), so that users of get_multi() can also benefit from the generic collection arguments.

Tests included.