### PR TITLE
Idiomatic usage of `ProtocolTrait` for `enum_dispatch`

### DIFF
--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::io::{Read, Write};
 
+use super::ProtocolTrait;
 use client::Stats;
 use error::{ClientError, CommandError, MemcacheError, ServerError};
 use std::borrow::Cow;
@@ -125,6 +126,211 @@ pub struct AsciiProtocol<C: Read + Write + Sized> {
     reader: CappedLineReader<C>,
 }
 
+impl ProtocolTrait for AsciiProtocol<Stream> {
+    fn auth(&mut self, username: &str, password: &str) -> Result<(), MemcacheError> {
+        return self.set("auth", format!("{} {}", username, password), 0);
+    }
+
+    fn version(&mut self) -> Result<String, MemcacheError> {
+        self.reader.get_mut().write(b"version\r\n")?;
+        self.reader.get_mut().flush()?;
+        self.reader.read_line(|response| {
+            let response = MemcacheError::try_from(response)?;
+            if !response.starts_with("VERSION") {
+                Err(ServerError::BadResponse(Cow::Owned(response.into())))?
+            }
+            let version = response.trim_start_matches("VERSION ").trim_end_matches("\r\n");
+            Ok(version.to_string())
+        })
+    }
+
+    fn flush(&mut self) -> Result<(), MemcacheError> {
+        write!(self.reader.get_mut(), "flush_all\r\n")?;
+        self.parse_ok_response()
+    }
+
+    fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError> {
+        write!(self.reader.get_mut(), "flush_all {}\r\n", delay)?;
+        self.reader.get_mut().flush()?;
+        self.parse_ok_response()
+    }
+
+    fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError> {
+        write!(self.reader.get_mut(), "get {}\r\n", key)?;
+
+        if let Some((k, v)) = self.parse_get_response(false)? {
+            if k != key {
+                Err(ServerError::BadResponse(Cow::Borrowed(
+                    "key doesn't match in the response",
+                )))?
+            } else if self.parse_get_response::<V>(false)?.is_none() {
+                Ok(Some(v))
+            } else {
+                Err(ServerError::BadResponse(Cow::Borrowed("Expected end of get response")))?
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn gets<V: FromMemcacheValueExt>(&mut self, keys: &[&str]) -> Result<HashMap<String, V>, MemcacheError> {
+        write!(self.reader.get_mut(), "gets {}\r\n", keys.join(" "))?;
+
+        let mut result: HashMap<String, V> = HashMap::with_capacity(keys.len());
+        // there will be atmost keys.len() "VALUE <...>" responses and one END response
+        for _ in 0..=keys.len() {
+            match self.parse_get_response(true)? {
+                Some((key, value)) => {
+                    result.insert(key, value);
+                }
+                None => return Ok(result),
+            }
+        }
+
+        Err(ServerError::BadResponse(Cow::Borrowed("Expected end of gets response")))?
+    }
+
+    fn cas<V: ToMemcacheValue<Stream>>(
+        &mut self,
+        key: &str,
+        value: V,
+        expiration: u32,
+        cas: u64,
+    ) -> Result<bool, MemcacheError> {
+        let options = Options {
+            exptime: expiration,
+            cas: Some(cas),
+            ..Default::default()
+        };
+        match self.store(StoreCommand::Cas, key, value, &options) {
+            Ok(t) => Ok(t),
+            Err(MemcacheError::CommandError(e)) if e == CommandError::KeyExists || e == CommandError::KeyNotFound => {
+                Ok(false)
+            }
+            e => e,
+        }
+    }
+
+    fn set<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V, expiration: u32) -> Result<(), MemcacheError> {
+        let options = Options {
+            exptime: expiration,
+            ..Default::default()
+        };
+        self.store(StoreCommand::Set, key, value, &options).map(|_| ())
+    }
+
+    fn add<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V, expiration: u32) -> Result<(), MemcacheError> {
+        let options = Options {
+            exptime: expiration,
+            ..Default::default()
+        };
+        self.store(StoreCommand::Add, key, value, &options).map(|_| ())
+    }
+
+    fn replace<V: ToMemcacheValue<Stream>>(
+        &mut self,
+        key: &str,
+        value: V,
+        expiration: u32,
+    ) -> Result<(), MemcacheError> {
+        let options = Options {
+            exptime: expiration,
+            ..Default::default()
+        };
+        self.store(StoreCommand::Replace, key, value, &options).map(|_| ())
+    }
+
+    fn append<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError> {
+        self.store(StoreCommand::Append, key, value, &Default::default())
+            .map(|_| ())
+    }
+
+    fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError> {
+        self.store(StoreCommand::Prepend, key, value, &Default::default())
+            .map(|_| ())
+    }
+
+    fn delete(&mut self, key: &str) -> Result<bool, MemcacheError> {
+        write!(self.reader.get_mut(), "delete {}\r\n", key)?;
+        self.reader.get_mut().flush()?;
+        self.reader
+            .read_line(|response| match MemcacheError::try_from(response) {
+                Ok(s) => {
+                    if s == "DELETED\r\n" {
+                        Ok(true)
+                    } else {
+                        Err(ServerError::BadResponse(Cow::Owned(s.into())).into())
+                    }
+                }
+                Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
+                Err(e) => Err(e),
+            })
+    }
+
+    fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
+        write!(self.reader.get_mut(), "incr {} {}\r\n", key, amount)?;
+        self.parse_u64_response()
+    }
+
+    fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
+        write!(self.reader.get_mut(), "decr {} {}\r\n", key, amount)?;
+        self.parse_u64_response()
+    }
+
+    fn touch(&mut self, key: &str, expiration: u32) -> Result<bool, MemcacheError> {
+        write!(self.reader.get_mut(), "touch {} {}\r\n", key, expiration)?;
+        self.reader.get_mut().flush()?;
+        self.reader
+            .read_line(|response| match MemcacheError::try_from(response) {
+                Ok(s) => {
+                    if s == "TOUCHED\r\n" {
+                        Ok(true)
+                    } else {
+                        Err(ServerError::BadResponse(Cow::Owned(s.into())).into())
+                    }
+                }
+                Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
+                Err(e) => Err(e),
+            })
+    }
+
+    fn stats(&mut self) -> Result<Stats, MemcacheError> {
+        self.reader.get_mut().write(b"stats\r\n")?;
+        self.reader.get_mut().flush()?;
+
+        enum Loop {
+            Break,
+            Continue,
+        }
+
+        let mut stats: Stats = HashMap::new();
+        loop {
+            let status = self.reader.read_line(|response| {
+                if response != END {
+                    return Ok(Loop::Break);
+                }
+                let s = MemcacheError::try_from(response)?;
+                if !s.starts_with("STAT") {
+                    return Err(ServerError::BadResponse(Cow::Owned(s.into())))?;
+                }
+                let stat: Vec<_> = s.trim_end_matches("\r\n").split(" ").collect();
+                if stat.len() < 3 {
+                    return Err(ServerError::BadResponse(Cow::Owned(s.into())).into());
+                }
+                let key = stat[1];
+                let value = s.trim_start_matches(format!("STAT {}", key).as_str());
+                stats.insert(key.into(), value.into());
+
+                Ok(Loop::Continue)
+            })?;
+
+            if let Loop::Break = status {
+                break Ok(stats);
+            }
+        }
+    }
+}
+
 impl AsciiProtocol<Stream> {
     pub(crate) fn new(stream: Stream) -> Self {
         Self {
@@ -134,10 +340,6 @@ impl AsciiProtocol<Stream> {
 
     pub(crate) fn stream(&mut self) -> &mut Stream {
         self.reader.get_mut()
-    }
-
-    pub(super) fn auth(&mut self, username: &str, password: &str) -> Result<(), MemcacheError> {
-        return self.set("auth", format!("{} {}", username, password), 0);
     }
 
     fn store<V: ToMemcacheValue<Stream>>(
@@ -200,19 +402,6 @@ impl AsciiProtocol<Stream> {
         })
     }
 
-    pub(super) fn version(&mut self) -> Result<String, MemcacheError> {
-        self.reader.get_mut().write(b"version\r\n")?;
-        self.reader.get_mut().flush()?;
-        self.reader.read_line(|response| {
-            let response = MemcacheError::try_from(response)?;
-            if !response.starts_with("VERSION") {
-                Err(ServerError::BadResponse(Cow::Owned(response.into())))?
-            }
-            let version = response.trim_start_matches("VERSION ").trim_end_matches("\r\n");
-            Ok(version.to_string())
-        })
-    }
-
     fn parse_ok_response(&mut self) -> Result<(), MemcacheError> {
         self.reader.read_line(|response| {
             let response = MemcacheError::try_from(response)?;
@@ -222,35 +411,6 @@ impl AsciiProtocol<Stream> {
                 Err(ServerError::BadResponse(Cow::Owned(response.into())))?
             }
         })
-    }
-
-    pub(super) fn flush(&mut self) -> Result<(), MemcacheError> {
-        write!(self.reader.get_mut(), "flush_all\r\n")?;
-        self.parse_ok_response()
-    }
-
-    pub(super) fn flush_with_delay(&mut self, delay: u32) -> Result<(), MemcacheError> {
-        write!(self.reader.get_mut(), "flush_all {}\r\n", delay)?;
-        self.reader.get_mut().flush()?;
-        self.parse_ok_response()
-    }
-
-    pub(super) fn get<V: FromMemcacheValueExt>(&mut self, key: &str) -> Result<Option<V>, MemcacheError> {
-        write!(self.reader.get_mut(), "get {}\r\n", key)?;
-
-        if let Some((k, v)) = self.parse_get_response(false)? {
-            if k != key {
-                Err(ServerError::BadResponse(Cow::Borrowed(
-                    "key doesn't match in the response",
-                )))?
-            } else if self.parse_get_response::<V>(false)?.is_none() {
-                Ok(Some(v))
-            } else {
-                Err(ServerError::BadResponse(Cow::Borrowed("Expected end of get response")))?
-            }
-        } else {
-            Ok(None)
-        }
     }
 
     fn parse_get_response<V: FromMemcacheValueExt>(
@@ -299,177 +459,10 @@ impl AsciiProtocol<Stream> {
         }
     }
 
-    pub(super) fn gets<V: FromMemcacheValueExt>(&mut self, keys: &[&str]) -> Result<HashMap<String, V>, MemcacheError> {
-        write!(self.reader.get_mut(), "gets {}\r\n", keys.join(" "))?;
-
-        let mut result: HashMap<String, V> = HashMap::with_capacity(keys.len());
-        // there will be atmost keys.len() "VALUE <...>" responses and one END response
-        for _ in 0..=keys.len() {
-            match self.parse_get_response(true)? {
-                Some((key, value)) => {
-                    result.insert(key, value);
-                }
-                None => return Ok(result),
-            }
-        }
-
-        Err(ServerError::BadResponse(Cow::Borrowed("Expected end of gets response")))?
-    }
-
-    pub(super) fn cas<V: ToMemcacheValue<Stream>>(
-        &mut self,
-        key: &str,
-        value: V,
-        expiration: u32,
-        cas: u64,
-    ) -> Result<bool, MemcacheError> {
-        let options = Options {
-            exptime: expiration,
-            cas: Some(cas),
-            ..Default::default()
-        };
-        match self.store(StoreCommand::Cas, key, value, &options) {
-            Ok(t) => Ok(t),
-            Err(MemcacheError::CommandError(e)) if e == CommandError::KeyExists || e == CommandError::KeyNotFound => {
-                Ok(false)
-            }
-            e => e,
-        }
-    }
-
-    pub(super) fn set<V: ToMemcacheValue<Stream>>(
-        &mut self,
-        key: &str,
-        value: V,
-        expiration: u32,
-    ) -> Result<(), MemcacheError> {
-        let options = Options {
-            exptime: expiration,
-            ..Default::default()
-        };
-        self.store(StoreCommand::Set, key, value, &options).map(|_| ())
-    }
-
-    pub(super) fn add<V: ToMemcacheValue<Stream>>(
-        &mut self,
-        key: &str,
-        value: V,
-        expiration: u32,
-    ) -> Result<(), MemcacheError> {
-        let options = Options {
-            exptime: expiration,
-            ..Default::default()
-        };
-        self.store(StoreCommand::Add, key, value, &options).map(|_| ())
-    }
-
-    pub(super) fn replace<V: ToMemcacheValue<Stream>>(
-        &mut self,
-        key: &str,
-        value: V,
-        expiration: u32,
-    ) -> Result<(), MemcacheError> {
-        let options = Options {
-            exptime: expiration,
-            ..Default::default()
-        };
-        self.store(StoreCommand::Replace, key, value, &options).map(|_| ())
-    }
-
-    pub(super) fn append<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError> {
-        self.store(StoreCommand::Append, key, value, &Default::default())
-            .map(|_| ())
-    }
-
-    pub(super) fn prepend<V: ToMemcacheValue<Stream>>(&mut self, key: &str, value: V) -> Result<(), MemcacheError> {
-        self.store(StoreCommand::Prepend, key, value, &Default::default())
-            .map(|_| ())
-    }
-
-    pub(super) fn delete(&mut self, key: &str) -> Result<bool, MemcacheError> {
-        write!(self.reader.get_mut(), "delete {}\r\n", key)?;
-        self.reader.get_mut().flush()?;
-        self.reader
-            .read_line(|response| match MemcacheError::try_from(response) {
-                Ok(s) => {
-                    if s == "DELETED\r\n" {
-                        Ok(true)
-                    } else {
-                        Err(ServerError::BadResponse(Cow::Owned(s.into())).into())
-                    }
-                }
-                Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
-                Err(e) => Err(e),
-            })
-    }
-
     fn parse_u64_response(&mut self) -> Result<u64, MemcacheError> {
         self.reader.read_line(|response| {
             let s = MemcacheError::try_from(response)?;
             Ok(s.trim_end_matches("\r\n").parse::<u64>()?)
         })
-    }
-
-    pub(super) fn increment(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
-        write!(self.reader.get_mut(), "incr {} {}\r\n", key, amount)?;
-        self.parse_u64_response()
-    }
-
-    pub(super) fn decrement(&mut self, key: &str, amount: u64) -> Result<u64, MemcacheError> {
-        write!(self.reader.get_mut(), "decr {} {}\r\n", key, amount)?;
-        self.parse_u64_response()
-    }
-
-    pub(super) fn touch(&mut self, key: &str, expiration: u32) -> Result<bool, MemcacheError> {
-        write!(self.reader.get_mut(), "touch {} {}\r\n", key, expiration)?;
-        self.reader.get_mut().flush()?;
-        self.reader
-            .read_line(|response| match MemcacheError::try_from(response) {
-                Ok(s) => {
-                    if s == "TOUCHED\r\n" {
-                        Ok(true)
-                    } else {
-                        Err(ServerError::BadResponse(Cow::Owned(s.into())).into())
-                    }
-                }
-                Err(MemcacheError::CommandError(CommandError::KeyNotFound)) => Ok(false),
-                Err(e) => Err(e),
-            })
-    }
-
-    pub(super) fn stats(&mut self) -> Result<Stats, MemcacheError> {
-        self.reader.get_mut().write(b"stats\r\n")?;
-        self.reader.get_mut().flush()?;
-
-        enum Loop {
-            Break,
-            Continue,
-        }
-
-        let mut stats: Stats = HashMap::new();
-        loop {
-            let status = self.reader.read_line(|response| {
-                if response != END {
-                    return Ok(Loop::Break);
-                }
-                let s = MemcacheError::try_from(response)?;
-                if !s.starts_with("STAT") {
-                    return Err(ServerError::BadResponse(Cow::Owned(s.into())))?;
-                }
-                let stat: Vec<_> = s.trim_end_matches("\r\n").split(" ").collect();
-                if stat.len() < 3 {
-                    return Err(ServerError::BadResponse(Cow::Owned(s.into())).into());
-                }
-                let key = stat[1];
-                let value = s.trim_start_matches(format!("STAT {}", key).as_str());
-                stats.insert(key.into(), value.into());
-
-                Ok(Loop::Continue)
-            })?;
-
-            if let Loop::Break = status {
-                break Ok(stats);
-            }
-        }
     }
 }


### PR DESCRIPTION
@kaj brought to my attention in #115 that `memcache` is using an unintended side effect of `enum_dispatch`, which caused some issues after v0.2.3 was released. Those changes have been rolled back and re-released in v0.3.0, but it would be good to update the implementation here as well.

Essentially, this PR just directly implements `ProtocolTrait` for `AsciiProtocol<Stream>` and `BinaryProtocol` by moving the corresponding methods 1-to-1 into the corresponding impl block. That allows them to benefit from Rust's trait semantics.