### PR TITLE
:heavy_plus_sign: Export Stream as public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,8 @@ mod value;
 
 pub use crate::client::{Client, Connectable};
 pub use crate::error::{ClientError, CommandError, MemcacheError, ServerError};
+pub use crate::stream::Stream;
 pub use crate::value::{FromMemcacheValue, FromMemcacheValueExt, ToMemcacheValue};
-pub use crate::stream::{Stream};
 pub use r2d2::Error;
 
 /// Create a memcached client instance and connect to memcached server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ mod value;
 pub use crate::client::{Client, Connectable};
 pub use crate::error::{ClientError, CommandError, MemcacheError, ServerError};
 pub use crate::value::{FromMemcacheValue, FromMemcacheValueExt, ToMemcacheValue};
+pub use crate::stream::{Stream};
 pub use r2d2::Error;
 
 /// Create a memcached client instance and connect to memcached server.


### PR DESCRIPTION
Needed so that I could implement a wrapper on this crate, it would look like this:

```
/// Memcache client wrapper
pub struct Memcached {
    /// Actual Memcache client
    client: Option<memcache::Client>,
}

impl Memcached {
    ...

    // Here I need to import `Stream`, however it is not exported from `rust-memcache`
    pub fn set<V: ToMemcacheValue<Stream>>(&self, key: &str, value: V, expiration: u32) {
        self.client
            .as_ref()
            .map_or((), |client| match client.set(key, value, expiration) {
                Ok(_) => (),
                Err(error) => {
                    error!(%error, "Memcached set failed for key: `{}`", key);
                }
            })
    }
}
```