### PR TITLE
client: add with_pool method

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -89,6 +89,13 @@ impl Client {
         })
     }
 
+    pub fn with_pool(pool: Pool<ConnectionManager>) -> Result<Self, MemcacheError> {
+        Ok(Client {
+            connections: vec![pool],
+            hash_function: default_hash_function,
+        })
+    }
+
     pub fn connect<C: Connectable>(target: C) -> Result<Self, MemcacheError> {
         Self::with_pool_size(target, 1)
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -34,12 +34,14 @@ impl Deref for Connection {
     }
 }
 
-pub(crate) struct ConnectionManager {
+/// Memcache connection manager implementing rd2d Pool ManageConnection
+pub struct ConnectionManager {
     url: Url,
 }
 
 impl ConnectionManager {
-    pub(crate) fn new(url: Url) -> Self {
+    /// Initialize connection manager with given Url
+    pub fn new(url: Url) -> Self {
         Self { url }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,10 +81,15 @@ mod stream;
 mod value;
 
 pub use crate::client::{Client, Connectable};
+pub use crate::connection::ConnectionManager;
 pub use crate::error::{ClientError, CommandError, MemcacheError, ServerError};
 pub use crate::stream::Stream;
 pub use crate::value::{FromMemcacheValue, FromMemcacheValueExt, ToMemcacheValue};
 pub use r2d2::Error;
+pub use url::{ParseError as UrlParseError, Url};
+
+/// R2D2 connection pool
+pub type Pool = r2d2::Pool<connection::ConnectionManager>;
 
 /// Create a memcached client instance and connect to memcached server.
 ///


### PR DESCRIPTION
Exposing rd2d pool to be able to pass properly built pool into Memcache, because of underlying connection_timeout setting in rd2d::Pool it default to 30 seconds https://docs.rs/r2d2/0.8.9/r2d2/struct.Builder.html#method.connection_timeout which is too high running in production 