### PR TITLE
feature: add mcrouter support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [features]
 default = ["tls"]
 tls = ["openssl"]
+mcrouter = []
 
 [dependencies]
 byteorder = "1"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,19 @@
+use r2d2::Pool;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::time::Duration;
-
 use url::Url;
+
+#[cfg(not(feature = "mcrouter"))]
+use crate::protocol::Protocol;
+#[cfg(not(feature = "mcrouter"))]
+use std::time::Duration;
 
 use crate::connection::ConnectionManager;
 use crate::error::{ClientError, MemcacheError};
-use crate::protocol::{Protocol, ProtocolTrait};
+use crate::protocol::ProtocolTrait;
 use crate::stream::Stream;
 use crate::value::{FromMemcacheValueExt, ToMemcacheValue};
-use r2d2::Pool;
 
 pub type Stats = HashMap<String, String>;
 
@@ -106,6 +109,7 @@ impl Client {
     /// let client = memcache::Client::connect("memcache://localhost:12345").unwrap();
     /// client.set_read_timeout(Some(::std::time::Duration::from_secs(3))).unwrap();
     /// ```
+    #[cfg(not(feature = "mcrouter"))]
     pub fn set_read_timeout(&self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
         for conn in self.connections.iter() {
             let mut conn = conn.get()?;
@@ -125,6 +129,7 @@ impl Client {
     /// let client = memcache::Client::connect("memcache://localhost:12345?protocol=ascii").unwrap();
     /// client.set_write_timeout(Some(::std::time::Duration::from_secs(3))).unwrap();
     /// ```
+    #[cfg(not(feature = "mcrouter"))]
     pub fn set_write_timeout(&self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
         for conn in self.connections.iter() {
             let mut conn = conn.get()?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -200,7 +200,7 @@ impl Transport {
 
 fn tcp_stream(url: &Url, opts: &TcpOptions) -> Result<TcpStream, MemcacheError> {
     let tcp_stream = TcpStream::connect(&*url.socket_addrs(|| None)?)?;
-    if opts.timeout.is_some() {
+    if cfg!(not(feature = "mcrouter")) && opts.timeout.is_some() {
         tcp_stream.set_read_timeout(opts.timeout)?;
         tcp_stream.set_write_timeout(opts.timeout)?;
     }

--- a/src/protocol/ascii.rs
+++ b/src/protocol/ascii.rs
@@ -338,6 +338,7 @@ impl AsciiProtocol<Stream> {
         }
     }
 
+    #[cfg(not(feature = "mcrouter"))]
     pub(crate) fn stream(&mut self) -> &mut Stream {
         self.reader.get_mut()
     }

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -4,13 +4,17 @@ use std::io::{self, Read, Write};
 use std::net::TcpStream;
 #[cfg(unix)]
 use std::os::unix::net::UnixStream;
-use std::time::Duration;
 
-pub(crate) use self::udp_stream::UdpStream;
-use crate::error::MemcacheError;
+#[cfg(not(feature = "mcrouter"))]
+use std::time::Duration;
 
 #[cfg(feature = "tls")]
 use openssl::ssl::SslStream;
+
+#[cfg(not(feature = "mcrouter"))]
+use crate::error::MemcacheError;
+
+pub(crate) use self::udp_stream::UdpStream;
 
 pub enum Stream {
     Tcp(TcpStream),
@@ -22,6 +26,7 @@ pub enum Stream {
 }
 
 impl Stream {
+    #[cfg(not(feature = "mcrouter"))]
     pub(super) fn set_read_timeout(&mut self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
         match self {
             Stream::Tcp(ref conn) => conn.set_read_timeout(timeout)?,
@@ -34,6 +39,7 @@ impl Stream {
         Ok(())
     }
 
+    #[cfg(not(feature = "mcrouter"))]
     pub(super) fn set_write_timeout(&mut self, timeout: Option<Duration>) -> Result<(), MemcacheError> {
         match self {
             Stream::Tcp(ref conn) => conn.set_write_timeout(timeout)?,

--- a/src/stream/udp_stream.rs
+++ b/src/stream/udp_stream.rs
@@ -5,9 +5,11 @@ use std::collections::HashMap;
 use std::io;
 use std::io::{Error, ErrorKind, Read, Write};
 use std::net::UdpSocket;
-use std::time::Duration;
 use std::u16;
 use url::Url;
+
+#[cfg(not(feature = "mcrouter"))]
+use std::time::Duration;
 
 pub struct UdpStream {
     socket: UdpSocket,
@@ -28,10 +30,12 @@ impl UdpStream {
         });
     }
 
+    #[cfg(not(feature = "mcrouter"))]
     pub(crate) fn set_read_timeout(&self, duration: Option<Duration>) -> Result<(), MemcacheError> {
         Ok(self.socket.set_read_timeout(duration)?)
     }
 
+    #[cfg(not(feature = "mcrouter"))]
     pub(crate) fn set_write_timeout(&self, duration: Option<Duration>) -> Result<(), MemcacheError> {
         Ok(self.socket.set_write_timeout(duration)?)
     }


### PR DESCRIPTION
Adding mcrouter feature (Facebook library to pooling memcached https://github.com/facebook/mcrouter).

When connected directly to mcrouter it does not support setting read/write timeout. Response header is not memcache MagicByte. 

> ERROR r2d2: Expected 0x81 as magic in response header, but found: 43