### PR TITLE
Add connect_timeout option and allow for fractional timeouts

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -81,8 +81,8 @@ impl Client {
             let timeout = parsed
                 .query_pairs()
                 .find(|&(ref k, ref _v)| k == "connect_timeout")
-                .and_then(|(ref _k, ref v)| v.parse::<u64>().ok())
-                .map(Duration::from_secs);
+                .and_then(|(ref _k, ref v)| v.parse::<f64>().ok())
+                .map(Duration::from_secs_f64);
             let builder = r2d2::Pool::builder().max_size(size);
             let builder = if let Some(timeout) = timeout {
                 builder.connection_timeout(timeout)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -148,8 +148,8 @@ impl TcpOptions {
         let timeout = url
             .query_pairs()
             .find(|&(ref k, ref _v)| k == "timeout")
-            .and_then(|(ref _k, ref v)| v.parse::<u64>().ok())
-            .map(Duration::from_secs);
+            .and_then(|(ref _k, ref v)| v.parse::<f64>().ok())
+            .map(Duration::from_secs_f64);
         TcpOptions {
             nodelay: nodelay,
             timeout: timeout,


### PR DESCRIPTION
This includes #133 and adds what I proposed in #134 to use f64 instead of i64 to get fractional timeouts.  It still has #133's awkwardness, which I am happy to correct with guidance.

Using the `set_read_timeout` and `set_write_timeout` you could use a millisecond duration, but there is no such interface for the connect timeout, and I think this would be a more consistent approach, while still being backward compatible.