### PR TITLE
:green_heart: remove redundant imports

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-use r2d2;
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
@@ -6,7 +5,6 @@ use std::io;
 use std::num;
 use std::str;
 use std::string;
-use url;
 
 /// Client-side errors
 #[derive(Debug, PartialEq)]

--- a/src/stream/udp_stream.rs
+++ b/src/stream/udp_stream.rs
@@ -1,6 +1,5 @@
 use crate::error::MemcacheError;
 use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
-use rand;
 use std::collections::HashMap;
 use std::io;
 use std::io::{Error, ErrorKind, Read, Write};


### PR DESCRIPTION
resolves #144

Unfortunately the issue of `flags` being unread in the ascii protocol isn't something we can easily fix as part of this PR, as we currently don't expose functionality to allow consumers to pass flags in for their keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Improved database connection pooling and URL handling by optimizing library usage.
	- Enhanced dependency management by refining random number generation in network streams.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->