### PR TITLE
Add experimental meta protocol module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2024"
 [features]
 default = ["tls"]
 tls = ["openssl"]
+tokio = ["dep:tokio"]
 
 [dependencies]
 byteorder = "1"
@@ -20,3 +21,4 @@ rand = "0.10"
 enum_dispatch = "0.3"
 openssl = { version = "^0.10", optional = true }
 r2d2 = "^0.8"
+tokio = { version = "1", features = ["io-util", "net"], optional = true }

--- a/src/exp/async_connection.rs
+++ b/src/exp/async_connection.rs
@@ -1,0 +1,77 @@
+//! Tokio TCP transport for meta protocol commands.
+
+use std::borrow::Cow;
+use std::io;
+
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpStream, ToSocketAddrs};
+
+use crate::error::{MemcacheError, ServerError};
+
+use super::meta_command::{MetaCommand, MetaResponse};
+
+/// A buffered tokio TCP connection that speaks the meta protocol.
+///
+/// The async counterpart of [`MetaConnection`](super::MetaConnection), with
+/// the same framing rules: one response per [`receive`](Self::receive),
+/// quiet-mode (`q`) commands are not handled here.
+pub struct AsyncMetaConnection {
+    reader: BufReader<TcpStream>,
+}
+
+impl AsyncMetaConnection {
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> Result<AsyncMetaConnection, MemcacheError> {
+        let stream = TcpStream::connect(addr).await?;
+        stream.set_nodelay(true)?;
+        Ok(AsyncMetaConnection::from_stream(stream))
+    }
+
+    pub fn from_stream(stream: TcpStream) -> AsyncMetaConnection {
+        AsyncMetaConnection {
+            reader: BufReader::new(stream),
+        }
+    }
+
+    /// Encode and write a single command.
+    pub async fn send(&mut self, command: &MetaCommand) -> Result<(), MemcacheError> {
+        let payload = command.encode()?;
+        self.reader.write_all(&payload).await?;
+        self.reader.flush().await?;
+        Ok(())
+    }
+
+    /// Read one framed response, including the data block of a `VA` response.
+    pub async fn receive(&mut self) -> Result<MetaResponse, MemcacheError> {
+        let line = self.read_line().await?;
+        let mut response = MetaResponse::parse_header(&line)?;
+        if let Some(datalen) = response.datalen {
+            let mut value = vec![0u8; datalen + 2];
+            self.reader.read_exact(&mut value).await?;
+            if &value[datalen..] != b"\r\n" {
+                return Err(ServerError::BadResponse(Cow::Borrowed("data block missing CRLF terminator")).into());
+            }
+            value.truncate(datalen);
+            response.value = Some(value);
+        }
+        Ok(response)
+    }
+
+    /// Send a command and read its response.
+    pub async fn execute(&mut self, command: &MetaCommand) -> Result<MetaResponse, MemcacheError> {
+        self.send(command).await?;
+        self.receive().await
+    }
+
+    async fn read_line(&mut self) -> Result<Vec<u8>, MemcacheError> {
+        let mut line = Vec::new();
+        self.reader.read_until(b'\n', &mut line).await?;
+        if !line.ends_with(b"\n") {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into());
+        }
+        line.pop();
+        if line.ends_with(b"\r") {
+            line.pop();
+        }
+        Ok(line)
+    }
+}

--- a/src/exp/connection.rs
+++ b/src/exp/connection.rs
@@ -1,0 +1,75 @@
+//! Blocking TCP transport for meta protocol commands.
+
+use std::borrow::Cow;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+
+use crate::error::{MemcacheError, ServerError};
+
+use super::meta_command::{MetaCommand, MetaResponse};
+
+/// A buffered, blocking TCP connection that speaks the meta protocol.
+///
+/// This is a thin transport: it writes encoded commands and reads framed
+/// responses, one at a time. Quiet-mode (`q`) commands that suppress
+/// successful responses are not handled here; [`receive`](Self::receive)
+/// always expects a response line.
+pub struct MetaConnection {
+    reader: BufReader<TcpStream>,
+}
+
+impl MetaConnection {
+    pub fn connect<A: ToSocketAddrs>(addr: A) -> Result<MetaConnection, MemcacheError> {
+        let stream = TcpStream::connect(addr)?;
+        stream.set_nodelay(true)?;
+        Ok(MetaConnection::from_stream(stream))
+    }
+
+    pub fn from_stream(stream: TcpStream) -> MetaConnection {
+        MetaConnection {
+            reader: BufReader::new(stream),
+        }
+    }
+
+    /// Encode and write a single command.
+    pub fn send(&mut self, command: &MetaCommand) -> Result<(), MemcacheError> {
+        let payload = command.encode()?;
+        self.reader.get_mut().write_all(&payload)?;
+        Ok(())
+    }
+
+    /// Read one framed response, including the data block of a `VA` response.
+    pub fn receive(&mut self) -> Result<MetaResponse, MemcacheError> {
+        let line = self.read_line()?;
+        let mut response = MetaResponse::parse_header(&line)?;
+        if let Some(datalen) = response.datalen {
+            let mut value = vec![0u8; datalen + 2];
+            self.reader.read_exact(&mut value)?;
+            if &value[datalen..] != b"\r\n" {
+                return Err(ServerError::BadResponse(Cow::Borrowed("data block missing CRLF terminator")).into());
+            }
+            value.truncate(datalen);
+            response.value = Some(value);
+        }
+        Ok(response)
+    }
+
+    /// Send a command and read its response.
+    pub fn execute(&mut self, command: &MetaCommand) -> Result<MetaResponse, MemcacheError> {
+        self.send(command)?;
+        self.receive()
+    }
+
+    fn read_line(&mut self) -> Result<Vec<u8>, MemcacheError> {
+        let mut line = Vec::new();
+        self.reader.read_until(b'\n', &mut line)?;
+        if !line.ends_with(b"\n") {
+            return Err(io::Error::from(io::ErrorKind::UnexpectedEof).into());
+        }
+        line.pop();
+        if line.ends_with(b"\r") {
+            line.pop();
+        }
+        Ok(line)
+    }
+}

--- a/src/exp/meta_api.rs
+++ b/src/exp/meta_api.rs
@@ -1,0 +1,694 @@
+//! Typed 1:1 mapping of the memcached meta protocol.
+//!
+//! This module builds wire commands (`mg`/`ms`/`md`/`ma`/`mn`/`me`) from
+//! option structs and parses wire responses into [`MetaCommandResult`]. Every
+//! option field corresponds to exactly one protocol flag. This layer performs
+//! no serialization and no semantic interpretation of results; both belong to
+//! the high-level client. Validation is limited to argument ranges and
+//! combinations the protocol silently ignores.
+//!
+//! The `q` (noreply) and `b` (base64 key) flags are intentionally not
+//! exposed: quiet semantics are an internal concern of the pipeline executor,
+//! and binary keys are base64-encoded automatically by
+//! [`MetaCommand`](super::MetaCommand).
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+use crate::error::{ClientError, MemcacheError};
+
+use super::meta_command::{MetaCommand, MetaOp, MetaResponse, ReturnCode, base64_decode, encode_key};
+
+const OPAQUE_MAX: usize = 32;
+
+fn invalid<T>(message: &'static str) -> Result<T, MemcacheError> {
+    Err(ClientError::Error(Cow::Borrowed(message)).into())
+}
+
+fn opaque_flag(opaque: &[u8]) -> Result<Vec<u8>, MemcacheError> {
+    if opaque.is_empty() || opaque.len() > OPAQUE_MAX {
+        return invalid("opaque must be 1-32 bytes");
+    }
+    if opaque.iter().any(|&byte| byte <= 0x20 || byte == 0x7f) {
+        return invalid("opaque must not contain whitespace or control bytes");
+    }
+    let mut flag = Vec::with_capacity(opaque.len() + 1);
+    flag.push(b'O');
+    flag.extend_from_slice(opaque);
+    Ok(flag)
+}
+
+struct FlagBuilder(Vec<Vec<u8>>);
+
+impl FlagBuilder {
+    fn new() -> FlagBuilder {
+        FlagBuilder(Vec::new())
+    }
+
+    fn marker(&mut self, enabled: bool, wire: &'static [u8]) {
+        if enabled {
+            self.0.push(wire.to_vec());
+        }
+    }
+
+    fn token(&mut self, prefix: u8, value: Option<u64>) {
+        if let Some(value) = value {
+            let mut flag = vec![prefix];
+            flag.extend_from_slice(value.to_string().as_bytes());
+            self.0.push(flag);
+        }
+    }
+
+    fn opaque(&mut self, opaque: Option<&[u8]>) -> Result<(), MemcacheError> {
+        if let Some(opaque) = opaque {
+            self.0.push(opaque_flag(opaque)?);
+        }
+        Ok(())
+    }
+
+    fn into_inner(self) -> Vec<Vec<u8>> {
+        self.0
+    }
+}
+
+/// Options for [`build_get`] (`mg`). Each field maps to one protocol flag.
+#[derive(Debug, Clone)]
+pub struct GetOptions {
+    /// `v` — return the item value.
+    pub value: bool,
+    /// `f` — return the client flags.
+    pub return_client_flags: bool,
+    /// `c` — return the item CAS.
+    pub return_cas: bool,
+    /// `t` — return the remaining TTL.
+    pub return_ttl: bool,
+    /// `s` — return the stored size.
+    pub return_size: bool,
+    /// `l` — return seconds since last access.
+    pub return_last_access: bool,
+    /// `h` — return whether the item was hit before.
+    pub return_hit_before: bool,
+    /// `k` — echo the key in the response.
+    pub return_key: bool,
+    /// `u` — don't bump the item in the LRU.
+    pub no_lru_bump: bool,
+    /// `T<ttl>` — update the item TTL.
+    pub touch: Option<u32>,
+    /// `N<ttl>` — vivify a missing item with this TTL and grant a lease.
+    pub vivify_ttl: Option<u32>,
+    /// `R<ttl>` — grant a recache lease when the remaining TTL is below this.
+    pub recache_ttl: Option<u32>,
+    /// `C<cas>` — suppress the value when the item CAS still matches.
+    pub unless_cas: Option<u64>,
+    /// `E<cas>` — replace the item CAS with this value.
+    pub new_cas: Option<u64>,
+    /// `O<token>` — opaque token echoed back in the response.
+    pub opaque: Option<Vec<u8>>,
+}
+
+impl Default for GetOptions {
+    fn default() -> GetOptions {
+        GetOptions {
+            value: true,
+            return_client_flags: false,
+            return_cas: false,
+            return_ttl: false,
+            return_size: false,
+            return_last_access: false,
+            return_hit_before: false,
+            return_key: false,
+            no_lru_bump: false,
+            touch: None,
+            vivify_ttl: None,
+            recache_ttl: None,
+            unless_cas: None,
+            new_cas: None,
+            opaque: None,
+        }
+    }
+}
+
+pub fn build_get(key: impl Into<Vec<u8>>, options: &GetOptions) -> Result<MetaCommand, MemcacheError> {
+    if options.recache_ttl == Some(0) {
+        return invalid("recache_ttl must be >= 1");
+    }
+    let mut flags = FlagBuilder::new();
+    flags.marker(options.value, b"v");
+    flags.marker(options.return_client_flags, b"f");
+    flags.marker(options.return_cas, b"c");
+    flags.marker(options.return_ttl, b"t");
+    flags.marker(options.return_size, b"s");
+    flags.marker(options.return_last_access, b"l");
+    flags.marker(options.return_hit_before, b"h");
+    flags.marker(options.return_key, b"k");
+    flags.marker(options.no_lru_bump, b"u");
+    flags.token(b'T', options.touch.map(u64::from));
+    flags.token(b'N', options.vivify_ttl.map(u64::from));
+    flags.token(b'R', options.recache_ttl.map(u64::from));
+    flags.token(b'C', options.unless_cas);
+    flags.token(b'E', options.new_cas);
+    flags.opaque(options.opaque.as_deref())?;
+    let mut command = MetaCommand::new(MetaOp::Get, key);
+    command.flags = flags.into_inner();
+    Ok(command)
+}
+
+/// Storage mode for [`build_set`] (`ms` `M` flag).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SetMode {
+    /// Unconditional store (the protocol default, no mode flag).
+    #[default]
+    Set,
+    /// `ME` — store only when the item does not exist.
+    Add,
+    /// `MR` — store only when the item exists.
+    Replace,
+    /// `MA` — append raw bytes to the stored value.
+    Append,
+    /// `MP` — prepend raw bytes to the stored value.
+    Prepend,
+}
+
+impl SetMode {
+    fn flag(self) -> Option<&'static [u8]> {
+        match self {
+            SetMode::Set => None,
+            SetMode::Add => Some(b"ME"),
+            SetMode::Replace => Some(b"MR"),
+            SetMode::Append => Some(b"MA"),
+            SetMode::Prepend => Some(b"MP"),
+        }
+    }
+}
+
+/// Options for [`build_set`] (`ms`). Each field maps to one protocol flag.
+#[derive(Debug, Clone, Default)]
+pub struct SetOptions {
+    /// `F<flags>` — client flags stored with the item.
+    pub client_flags: Option<u32>,
+    /// `T<ttl>` — item TTL.
+    pub ttl: Option<u32>,
+    /// `M<mode>` — storage mode.
+    pub mode: SetMode,
+    /// `C<cas>` — store only when the item CAS matches.
+    pub compare_cas: Option<u64>,
+    /// `E<cas>` — replace the item CAS with this value.
+    pub new_cas: Option<u64>,
+    /// `I` — invalidate: mark the item stale instead of replacing it.
+    pub invalidate: bool,
+    /// `N<ttl>` — for append/prepend, vivify a missing item with this TTL.
+    pub vivify_ttl: Option<u32>,
+    /// `c` — return the new item CAS.
+    pub return_cas: bool,
+    /// `s` — return the stored size.
+    pub return_size: bool,
+    /// `k` — echo the key in the response.
+    pub return_key: bool,
+    /// `O<token>` — opaque token echoed back in the response.
+    pub opaque: Option<Vec<u8>>,
+}
+
+pub fn build_set(
+    key: impl Into<Vec<u8>>,
+    value: impl Into<Vec<u8>>,
+    options: &SetOptions,
+) -> Result<MetaCommand, MemcacheError> {
+    let concatenation = matches!(options.mode, SetMode::Append | SetMode::Prepend);
+    if options.vivify_ttl.is_some() && !concatenation {
+        return invalid("vivify_ttl is only valid for append/prepend");
+    }
+    if options.ttl.is_some() && concatenation {
+        // The server ignores T for concatenation; the miss path takes its
+        // TTL from N (vivify_ttl) instead. Reject the no-op.
+        return invalid("ttl is ignored for append/prepend; use vivify_ttl");
+    }
+    if options.compare_cas.is_some() && options.mode == SetMode::Add {
+        // Add only stores when no item exists, so there is no CAS to
+        // compare; the protocol leaves the combination undefined.
+        return invalid("compare_cas cannot be combined with add mode");
+    }
+    let mut flags = FlagBuilder::new();
+    if let Some(mode_flag) = options.mode.flag() {
+        flags.marker(true, mode_flag);
+    }
+    flags.marker(options.invalidate, b"I");
+    flags.marker(options.return_cas, b"c");
+    flags.marker(options.return_size, b"s");
+    flags.marker(options.return_key, b"k");
+    flags.token(b'F', options.client_flags.map(u64::from));
+    flags.token(b'T', options.ttl.map(u64::from));
+    flags.token(b'C', options.compare_cas);
+    flags.token(b'E', options.new_cas);
+    flags.token(b'N', options.vivify_ttl.map(u64::from));
+    flags.opaque(options.opaque.as_deref())?;
+    let mut command = MetaCommand::new(MetaOp::Set, key);
+    command.flags = flags.into_inner();
+    command.value = Some(value.into());
+    Ok(command)
+}
+
+/// Options for [`build_delete`] (`md`). Each field maps to one protocol flag.
+#[derive(Debug, Clone, Default)]
+pub struct DeleteOptions {
+    /// `C<cas>` — delete only when the item CAS matches.
+    pub compare_cas: Option<u64>,
+    /// `E<cas>` — for invalidate, replace the item CAS with this value.
+    pub new_cas: Option<u64>,
+    /// `I` — invalidate: mark the item stale instead of removing it.
+    pub invalidate: bool,
+    /// `T<ttl>` — for invalidate, the TTL the stale item keeps.
+    pub ttl: Option<u32>,
+    /// `x` — drop the value but keep the item.
+    pub drop_value: bool,
+    /// `k` — echo the key in the response.
+    pub return_key: bool,
+    /// `O<token>` — opaque token echoed back in the response.
+    pub opaque: Option<Vec<u8>>,
+}
+
+pub fn build_delete(key: impl Into<Vec<u8>>, options: &DeleteOptions) -> Result<MetaCommand, MemcacheError> {
+    if options.ttl.is_some() && !options.invalidate {
+        // The server only applies T when paired with I; reject the no-op.
+        return invalid("ttl is only applied when invalidate is set");
+    }
+    let mut flags = FlagBuilder::new();
+    flags.marker(options.invalidate, b"I");
+    flags.marker(options.drop_value, b"x");
+    flags.marker(options.return_key, b"k");
+    flags.token(b'C', options.compare_cas);
+    flags.token(b'E', options.new_cas);
+    flags.token(b'T', options.ttl.map(u64::from));
+    flags.opaque(options.opaque.as_deref())?;
+    let mut command = MetaCommand::new(MetaOp::Delete, key);
+    command.flags = flags.into_inner();
+    Ok(command)
+}
+
+/// Arithmetic direction for [`build_arithmetic`] (`ma` `M` flag).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ArithmeticMode {
+    /// Increment (the protocol default, no mode flag).
+    #[default]
+    Increment,
+    /// `MD` — decrement.
+    Decrement,
+}
+
+/// Options for [`build_arithmetic`] (`ma`). Each field maps to one protocol
+/// flag.
+#[derive(Debug, Clone)]
+pub struct ArithmeticOptions {
+    /// `D<delta>` — the delta to apply (the server defaults to 1).
+    pub delta: Option<u64>,
+    /// `M<mode>` — increment or decrement.
+    pub mode: ArithmeticMode,
+    /// `J<value>` — initial value when vivifying a missing item.
+    pub initial: Option<u64>,
+    /// `N<ttl>` — vivify a missing item with this TTL.
+    pub initial_ttl: Option<u32>,
+    /// `T<ttl>` — update the item TTL.
+    pub ttl: Option<u32>,
+    /// `C<cas>` — apply only when the item CAS matches.
+    pub compare_cas: Option<u64>,
+    /// `E<cas>` — replace the item CAS with this value.
+    pub new_cas: Option<u64>,
+    /// `v` — return the new value.
+    pub return_value: bool,
+    /// `t` — return the remaining TTL.
+    pub return_ttl: bool,
+    /// `c` — return the new item CAS.
+    pub return_cas: bool,
+    /// `k` — echo the key in the response.
+    pub return_key: bool,
+    /// `O<token>` — opaque token echoed back in the response.
+    pub opaque: Option<Vec<u8>>,
+}
+
+impl Default for ArithmeticOptions {
+    fn default() -> ArithmeticOptions {
+        ArithmeticOptions {
+            delta: None,
+            mode: ArithmeticMode::Increment,
+            initial: None,
+            initial_ttl: None,
+            ttl: None,
+            compare_cas: None,
+            new_cas: None,
+            return_value: true,
+            return_ttl: false,
+            return_cas: false,
+            return_key: false,
+            opaque: None,
+        }
+    }
+}
+
+pub fn build_arithmetic(key: impl Into<Vec<u8>>, options: &ArithmeticOptions) -> Result<MetaCommand, MemcacheError> {
+    if options.initial.is_some() && options.initial_ttl.is_none() {
+        // J is silently ignored without N; reject the no-op.
+        return invalid("initial requires initial_ttl to vivify on miss");
+    }
+    let mut flags = FlagBuilder::new();
+    flags.marker(options.mode == ArithmeticMode::Decrement, b"MD");
+    flags.marker(options.return_value, b"v");
+    flags.marker(options.return_ttl, b"t");
+    flags.marker(options.return_cas, b"c");
+    flags.marker(options.return_key, b"k");
+    flags.token(b'D', options.delta);
+    flags.token(b'N', options.initial_ttl.map(u64::from));
+    flags.token(b'J', options.initial);
+    flags.token(b'T', options.ttl.map(u64::from));
+    flags.token(b'C', options.compare_cas);
+    flags.token(b'E', options.new_cas);
+    flags.opaque(options.opaque.as_deref())?;
+    let mut command = MetaCommand::new(MetaOp::Arithmetic, key);
+    command.flags = flags.into_inner();
+    Ok(command)
+}
+
+/// Build an `mn` no-op, used as a pipeline barrier.
+pub fn build_noop() -> MetaCommand {
+    MetaCommand::new(MetaOp::Noop, Vec::new())
+}
+
+/// Build an `me` debug command.
+pub fn build_debug(key: impl Into<Vec<u8>>) -> Result<MetaCommand, MemcacheError> {
+    let key = key.into();
+    let (_, needs_base64) = encode_key(&key)?;
+    if needs_base64 {
+        // protocol.txt documents the `b` flag for `me`, but real servers
+        // (verified on memcached 1.6.45) look up the base64 token literally,
+        // so a binary-key debug would silently report a miss for a live item.
+        return invalid("meta debug does not support keys that require base64");
+    }
+    Ok(MetaCommand::new(MetaOp::Debug, key))
+}
+
+/// A fully parsed meta protocol response.
+///
+/// The typed fields are response flags decoded to native types; a field is
+/// `None` (or `false` for markers) when the server did not send the flag.
+/// `flags` keeps the raw tokens for anything this layer does not decode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaCommandResult {
+    /// The wire return code.
+    pub rc: ReturnCode,
+    /// The raw data block, if any.
+    pub value: Option<Vec<u8>>,
+    /// `c` — item CAS.
+    pub cas: Option<u64>,
+    /// `t` — remaining TTL (`-1` means unlimited).
+    pub ttl: Option<i64>,
+    /// `f` — client flags.
+    pub client_flags: Option<u32>,
+    /// `s` — stored size.
+    pub size: Option<u64>,
+    /// `l` — seconds since last access.
+    pub last_access: Option<u64>,
+    /// `h` — whether the item was hit before.
+    pub hit_before: Option<bool>,
+    /// `k` — the echoed key (base64-decoded when the `b` flag is present).
+    pub key: Option<Vec<u8>>,
+    /// `O` — the echoed opaque token.
+    pub opaque: Option<Vec<u8>>,
+    /// `W` — this client won a vivify/recache lease.
+    pub won: bool,
+    /// `Z` — another client holds the lease.
+    pub busy: bool,
+    /// `X` — the value is stale.
+    pub stale: bool,
+    /// The raw response flag tokens.
+    pub flags: Vec<Vec<u8>>,
+}
+
+impl MetaCommandResult {
+    /// Whether the command succeeded (`HD` or `VA`).
+    pub fn ok(&self) -> bool {
+        matches!(self.rc, ReturnCode::Hd | ReturnCode::Va)
+    }
+}
+
+fn parse_int<T: std::str::FromStr<Err = std::num::ParseIntError>>(token: &[u8]) -> Result<T, MemcacheError> {
+    Ok(std::str::from_utf8(token)?.parse::<T>()?)
+}
+
+/// Decode the response flags of a [`MetaResponse`] into a
+/// [`MetaCommandResult`]. Unknown flags are kept in `flags` but otherwise
+/// ignored.
+pub fn parse_meta_result(response: MetaResponse) -> Result<MetaCommandResult, MemcacheError> {
+    let mut result = MetaCommandResult {
+        rc: response.rc,
+        value: response.value,
+        cas: None,
+        ttl: None,
+        client_flags: None,
+        size: None,
+        last_access: None,
+        hit_before: None,
+        key: None,
+        opaque: None,
+        won: false,
+        busy: false,
+        stale: false,
+        flags: response.flags,
+    };
+    let mut key_base64 = false;
+    for flag in &result.flags {
+        let Some((&code, token)) = flag.split_first() else {
+            continue;
+        };
+        match code {
+            b'f' => result.client_flags = Some(parse_int(token)?),
+            b'c' => result.cas = Some(parse_int(token)?),
+            b't' => result.ttl = Some(parse_int(token)?),
+            b'l' => result.last_access = Some(parse_int(token)?),
+            b's' => result.size = Some(parse_int(token)?),
+            b'h' => result.hit_before = Some(token != b"0"),
+            b'k' => result.key = Some(token.to_vec()),
+            b'O' => result.opaque = Some(token.to_vec()),
+            b'W' => result.won = true,
+            b'Z' => result.busy = true,
+            b'X' => result.stale = true,
+            b'b' => key_base64 = true,
+            _ => {}
+        }
+    }
+    if key_base64 && let Some(key) = &result.key {
+        result.key = Some(base64_decode(key)?);
+    }
+    Ok(result)
+}
+
+/// Parse an `me` response into its `name=value` fields. Returns `None` on a
+/// miss (`EN`).
+pub fn parse_debug_result(response: &MetaResponse) -> Result<Option<HashMap<String, String>>, MemcacheError> {
+    if response.rc == ReturnCode::En {
+        return Ok(None);
+    }
+    if response.rc != ReturnCode::Me {
+        return Err(crate::error::ServerError::BadResponse(Cow::Owned(format!(
+            "unexpected debug response {:?}",
+            response.rc
+        )))
+        .into());
+    }
+    let mut fields = HashMap::new();
+    // The first token is the (possibly base64) key; the rest are name=value.
+    for token in response.flags.iter().skip(1) {
+        let mut split = token.splitn(2, |&byte| byte == b'=');
+        let name = split.next().unwrap_or_default();
+        let value = split.next().unwrap_or_default();
+        fields.insert(String::from_utf8(name.to_vec())?, String::from_utf8(value.to_vec())?);
+    }
+    Ok(Some(fields))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_get_default() {
+        let command = build_get("foo", &GetOptions::default()).unwrap();
+        assert_eq!(command.encode().unwrap(), b"mg foo v\r\n".to_vec());
+    }
+
+    #[test]
+    fn build_get_all_flags() {
+        let options = GetOptions {
+            value: true,
+            return_client_flags: true,
+            return_cas: true,
+            return_ttl: true,
+            return_size: true,
+            return_last_access: true,
+            return_hit_before: true,
+            return_key: true,
+            no_lru_bump: true,
+            touch: Some(60),
+            vivify_ttl: Some(30),
+            recache_ttl: Some(10),
+            unless_cas: Some(7),
+            new_cas: Some(8),
+            opaque: Some(b"tok".to_vec()),
+        };
+        let command = build_get("foo", &options).unwrap();
+        assert_eq!(
+            command.encode().unwrap(),
+            b"mg foo v f c t s l h k u T60 N30 R10 C7 E8 Otok\r\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn build_get_validation() {
+        let options = GetOptions {
+            recache_ttl: Some(0),
+            ..GetOptions::default()
+        };
+        assert!(build_get("foo", &options).is_err());
+    }
+
+    #[test]
+    fn build_set_modes() {
+        let command = build_set("foo", "bar", &SetOptions::default()).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ms foo 3\r\nbar\r\n".to_vec());
+
+        let options = SetOptions {
+            mode: SetMode::Add,
+            ttl: Some(60),
+            client_flags: Some(1),
+            return_cas: true,
+            ..SetOptions::default()
+        };
+        let command = build_set("foo", "bar", &options).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ms foo 3 ME c F1 T60\r\nbar\r\n".to_vec());
+    }
+
+    #[test]
+    fn build_set_validation() {
+        let append_with_ttl = SetOptions {
+            mode: SetMode::Append,
+            ttl: Some(60),
+            ..SetOptions::default()
+        };
+        assert!(build_set("foo", "bar", &append_with_ttl).is_err());
+
+        let set_with_vivify = SetOptions {
+            vivify_ttl: Some(60),
+            ..SetOptions::default()
+        };
+        assert!(build_set("foo", "bar", &set_with_vivify).is_err());
+
+        let add_with_cas = SetOptions {
+            mode: SetMode::Add,
+            compare_cas: Some(1),
+            ..SetOptions::default()
+        };
+        assert!(build_set("foo", "bar", &add_with_cas).is_err());
+    }
+
+    #[test]
+    fn build_delete_flags() {
+        let command = build_delete("foo", &DeleteOptions::default()).unwrap();
+        assert_eq!(command.encode().unwrap(), b"md foo\r\n".to_vec());
+
+        let options = DeleteOptions {
+            invalidate: true,
+            ttl: Some(30),
+            compare_cas: Some(5),
+            ..DeleteOptions::default()
+        };
+        let command = build_delete("foo", &options).unwrap();
+        assert_eq!(command.encode().unwrap(), b"md foo I C5 T30\r\n".to_vec());
+
+        let ttl_without_invalidate = DeleteOptions {
+            ttl: Some(30),
+            ..DeleteOptions::default()
+        };
+        assert!(build_delete("foo", &ttl_without_invalidate).is_err());
+    }
+
+    #[test]
+    fn build_arithmetic_flags() {
+        let command = build_arithmetic("counter", &ArithmeticOptions::default()).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ma counter v\r\n".to_vec());
+
+        let options = ArithmeticOptions {
+            mode: ArithmeticMode::Decrement,
+            delta: Some(2),
+            initial: Some(0),
+            initial_ttl: Some(60),
+            ..ArithmeticOptions::default()
+        };
+        let command = build_arithmetic("counter", &options).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ma counter MD v D2 N60 J0\r\n".to_vec());
+
+        let initial_without_ttl = ArithmeticOptions {
+            initial: Some(0),
+            ..ArithmeticOptions::default()
+        };
+        assert!(build_arithmetic("counter", &initial_without_ttl).is_err());
+    }
+
+    #[test]
+    fn build_noop_and_debug() {
+        assert_eq!(build_noop().encode().unwrap(), b"mn\r\n".to_vec());
+        assert_eq!(build_debug("foo").unwrap().encode().unwrap(), b"me foo\r\n".to_vec());
+        assert!(build_debug(b"a key".to_vec()).is_err());
+    }
+
+    #[test]
+    fn opaque_validation() {
+        for opaque in [&b""[..], &[b'x'; 33][..], b"a b", b"a\x7f"] {
+            let options = GetOptions {
+                opaque: Some(opaque.to_vec()),
+                ..GetOptions::default()
+            };
+            assert!(build_get("foo", &options).is_err(), "opaque {:?} should fail", opaque);
+        }
+    }
+
+    #[test]
+    fn parse_meta_result_flags() {
+        let mut response = MetaResponse::parse_header(b"VA 3 f1 c42 t-1 h1 l5 s3 W Otok kZm9v b").unwrap();
+        response.value = Some(b"bar".to_vec());
+        let result = parse_meta_result(response).unwrap();
+        assert!(result.ok());
+        assert_eq!(result.rc, ReturnCode::Va);
+        assert_eq!(result.value, Some(b"bar".to_vec()));
+        assert_eq!(result.client_flags, Some(1));
+        assert_eq!(result.cas, Some(42));
+        assert_eq!(result.ttl, Some(-1));
+        assert_eq!(result.hit_before, Some(true));
+        assert_eq!(result.last_access, Some(5));
+        assert_eq!(result.size, Some(3));
+        assert!(result.won);
+        assert!(!result.busy);
+        assert!(!result.stale);
+        assert_eq!(result.opaque, Some(b"tok".to_vec()));
+        assert_eq!(result.key, Some(b"foo".to_vec()));
+    }
+
+    #[test]
+    fn parse_meta_result_miss() {
+        let response = MetaResponse::parse_header(b"EN").unwrap();
+        let result = parse_meta_result(response).unwrap();
+        assert!(!result.ok());
+        assert_eq!(result.rc, ReturnCode::En);
+    }
+
+    #[test]
+    fn parse_debug_result_fields() {
+        let response = MetaResponse::parse_header(b"ME foo exp=-1 la=2 cas=3").unwrap();
+        let fields = parse_debug_result(&response).unwrap().unwrap();
+        assert_eq!(fields.get("exp").map(String::as_str), Some("-1"));
+        assert_eq!(fields.get("la").map(String::as_str), Some("2"));
+        assert_eq!(fields.get("cas").map(String::as_str), Some("3"));
+
+        let miss = MetaResponse::parse_header(b"EN").unwrap();
+        assert!(parse_debug_result(&miss).unwrap().is_none());
+
+        let unexpected = MetaResponse::parse_header(b"HD").unwrap();
+        assert!(parse_debug_result(&unexpected).is_err());
+    }
+}

--- a/src/exp/meta_command.rs
+++ b/src/exp/meta_command.rs
@@ -1,0 +1,382 @@
+//! Wire-level framing for the memcached meta protocol.
+//!
+//! [`MetaCommand`] assembles a request line (and optional data block) from a
+//! command code, key, flag tokens and value. [`MetaResponse`] parses a
+//! response header line. Neither type interprets flags; that belongs to the
+//! typed layer in [`super::meta_api`].
+
+use std::borrow::Cow;
+
+use crate::error::{ClientError, CommandError, MemcacheError, ServerError};
+
+/// memcached limits the key token *on the wire* to 250 bytes and the legacy
+/// text key may not contain whitespace or control characters. Keys that
+/// violate the latter are sent base64-encoded with the meta `b` flag; since
+/// the server checks the length before decoding, the base64 form (not the raw
+/// key) is what must fit in 250 bytes, which caps a binary key at ~186 raw
+/// bytes.
+pub const MAX_KEY_LENGTH: usize = 250;
+
+const BASE64_ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+pub(crate) fn base64_encode(input: &[u8]) -> Vec<u8> {
+    let mut output = Vec::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let triple =
+            (chunk[0] as u32) << 16 | (*chunk.get(1).unwrap_or(&0) as u32) << 8 | *chunk.get(2).unwrap_or(&0) as u32;
+        output.push(BASE64_ALPHABET[(triple >> 18) as usize & 63]);
+        output.push(BASE64_ALPHABET[(triple >> 12) as usize & 63]);
+        output.push(if chunk.len() > 1 {
+            BASE64_ALPHABET[(triple >> 6) as usize & 63]
+        } else {
+            b'='
+        });
+        output.push(if chunk.len() > 2 {
+            BASE64_ALPHABET[triple as usize & 63]
+        } else {
+            b'='
+        });
+    }
+    output
+}
+
+pub(crate) fn base64_decode(input: &[u8]) -> Result<Vec<u8>, MemcacheError> {
+    fn bad_base64() -> MemcacheError {
+        ServerError::BadResponse(Cow::Borrowed("invalid base64 token")).into()
+    }
+    fn value(byte: u8) -> Result<u32, MemcacheError> {
+        match byte {
+            b'A'..=b'Z' => Ok((byte - b'A') as u32),
+            b'a'..=b'z' => Ok((byte - b'a') as u32 + 26),
+            b'0'..=b'9' => Ok((byte - b'0') as u32 + 52),
+            b'+' => Ok(62),
+            b'/' => Ok(63),
+            _ => Err(bad_base64()),
+        }
+    }
+    if !input.len().is_multiple_of(4) {
+        return Err(bad_base64());
+    }
+    let mut output = Vec::with_capacity(input.len() / 4 * 3);
+    for chunk in input.chunks(4) {
+        let padding = chunk.iter().rev().take_while(|&&byte| byte == b'=').count();
+        if padding > 2 || (padding > 0 && !std::ptr::eq(chunk, input.chunks(4).last().unwrap())) {
+            return Err(bad_base64());
+        }
+        let mut triple = 0u32;
+        for (index, &byte) in chunk.iter().enumerate() {
+            let bits = if byte == b'=' {
+                // Only the trailing padding positions may hold '='.
+                if index < chunk.len() - padding {
+                    return Err(bad_base64());
+                }
+                0
+            } else {
+                value(byte)?
+            };
+            triple |= bits << (18 - index * 6);
+        }
+        output.push((triple >> 16) as u8);
+        if padding < 2 {
+            output.push((triple >> 8) as u8);
+        }
+        if padding < 1 {
+            output.push(triple as u8);
+        }
+    }
+    Ok(output)
+}
+
+/// Whether `key` can be sent verbatim (no whitespace/control chars).
+fn is_legacy_safe(key: &[u8]) -> bool {
+    key.iter().all(|&byte| byte > 0x20 && byte != 0x7f)
+}
+
+/// Return `(wire_key, needs_base64_flag)` for a raw key.
+pub(crate) fn encode_key(key: &[u8]) -> Result<(Cow<'_, [u8]>, bool), MemcacheError> {
+    let (wire_key, needs_base64) = if is_legacy_safe(key) {
+        (Cow::Borrowed(key), false)
+    } else {
+        (Cow::Owned(base64_encode(key)), true)
+    };
+    if wire_key.len() > MAX_KEY_LENGTH {
+        return Err(ClientError::KeyTooLong.into());
+    }
+    Ok((wire_key, needs_base64))
+}
+
+/// A meta protocol command code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetaOp {
+    /// `mg` — meta get.
+    Get,
+    /// `ms` — meta set.
+    Set,
+    /// `md` — meta delete.
+    Delete,
+    /// `ma` — meta arithmetic.
+    Arithmetic,
+    /// `mn` — meta no-op, used as a pipeline barrier.
+    Noop,
+    /// `me` — meta debug.
+    Debug,
+}
+
+impl MetaOp {
+    pub fn wire(self) -> &'static [u8] {
+        match self {
+            MetaOp::Get => b"mg",
+            MetaOp::Set => b"ms",
+            MetaOp::Delete => b"md",
+            MetaOp::Arithmetic => b"ma",
+            MetaOp::Noop => b"mn",
+            MetaOp::Debug => b"me",
+        }
+    }
+}
+
+/// A meta protocol response return code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReturnCode {
+    /// `HD` — success without a value block.
+    Hd,
+    /// `VA` — success with a value block.
+    Va,
+    /// `EN` — miss.
+    En,
+    /// `NS` — not stored.
+    Ns,
+    /// `EX` — item exists (CAS mismatch).
+    Ex,
+    /// `NF` — not found.
+    Nf,
+    /// `MN` — no-op marker.
+    Mn,
+    /// `ME` — debug line.
+    Me,
+}
+
+impl ReturnCode {
+    pub fn from_wire(token: &[u8]) -> Result<ReturnCode, MemcacheError> {
+        match token {
+            b"HD" => Ok(ReturnCode::Hd),
+            b"VA" => Ok(ReturnCode::Va),
+            b"EN" => Ok(ReturnCode::En),
+            b"NS" => Ok(ReturnCode::Ns),
+            b"EX" => Ok(ReturnCode::Ex),
+            b"NF" => Ok(ReturnCode::Nf),
+            b"MN" => Ok(ReturnCode::Mn),
+            b"ME" => Ok(ReturnCode::Me),
+            _ => Err(ServerError::BadResponse(Cow::Owned(format!(
+                "unknown return code {:?}",
+                String::from_utf8_lossy(token)
+            )))
+            .into()),
+        }
+    }
+}
+
+/// A meta protocol request: command code, key, flag tokens and optional data
+/// block. The data length token is derived from `value`; the base64 `b` flag
+/// is added automatically when the key requires it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaCommand {
+    pub op: MetaOp,
+    pub key: Vec<u8>,
+    pub flags: Vec<Vec<u8>>,
+    pub value: Option<Vec<u8>>,
+}
+
+impl MetaCommand {
+    pub fn new(op: MetaOp, key: impl Into<Vec<u8>>) -> MetaCommand {
+        MetaCommand {
+            op,
+            key: key.into(),
+            flags: Vec::new(),
+            value: None,
+        }
+    }
+
+    /// Encode the full request (header line plus data block) to wire bytes.
+    pub fn encode(&self) -> Result<Vec<u8>, MemcacheError> {
+        let mut buffer = Vec::new();
+        self.encode_into(&mut buffer)?;
+        Ok(buffer)
+    }
+
+    pub fn encode_into(&self, buffer: &mut Vec<u8>) -> Result<(), MemcacheError> {
+        buffer.extend_from_slice(self.op.wire());
+        if self.op == MetaOp::Noop {
+            // mn takes no key, flags or value.
+            buffer.extend_from_slice(b"\r\n");
+            return Ok(());
+        }
+        if self.key.is_empty() {
+            return Err(ClientError::Error(Cow::Borrowed("key must not be empty")).into());
+        }
+        let (wire_key, needs_base64) = encode_key(&self.key)?;
+        buffer.push(b' ');
+        buffer.extend_from_slice(&wire_key);
+        if let Some(value) = &self.value {
+            buffer.push(b' ');
+            buffer.extend_from_slice(value.len().to_string().as_bytes());
+        }
+        for flag in &self.flags {
+            buffer.push(b' ');
+            buffer.extend_from_slice(flag);
+        }
+        if needs_base64 && !self.flags.iter().any(|flag| flag.as_slice() == b"b") {
+            buffer.extend_from_slice(b" b");
+        }
+        buffer.extend_from_slice(b"\r\n");
+        if let Some(value) = &self.value {
+            buffer.extend_from_slice(value);
+            buffer.extend_from_slice(b"\r\n");
+        }
+        Ok(())
+    }
+}
+
+/// A lightly framed meta protocol response: return code, raw flag tokens and
+/// (for `VA`) the data block length. `value` is filled in by the transport
+/// after it reads the data block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetaResponse {
+    pub rc: ReturnCode,
+    pub datalen: Option<usize>,
+    pub flags: Vec<Vec<u8>>,
+    pub value: Option<Vec<u8>>,
+}
+
+impl MetaResponse {
+    /// Parse a response header line (without the trailing CRLF).
+    ///
+    /// Legacy `ERROR` / `CLIENT_ERROR` / `SERVER_ERROR` lines are converted
+    /// to the corresponding [`MemcacheError`].
+    pub fn parse_header(line: &[u8]) -> Result<MetaResponse, MemcacheError> {
+        let mut tokens = line.split(|&byte| byte == b' ').filter(|token| !token.is_empty());
+        let rc_token = tokens
+            .next()
+            .ok_or(ServerError::BadResponse(Cow::Borrowed("empty response line")))?;
+        match rc_token {
+            b"ERROR" => return Err(CommandError::InvalidCommand.into()),
+            b"CLIENT_ERROR" | b"SERVER_ERROR" => {
+                let message = String::from_utf8_lossy(&line[rc_token.len()..]).trim().to_string();
+                if rc_token == b"CLIENT_ERROR" {
+                    return Err(ClientError::Error(Cow::Owned(message)).into());
+                }
+                return Err(ServerError::Error(message).into());
+            }
+            _ => {}
+        }
+        let rc = ReturnCode::from_wire(rc_token)?;
+        let mut flags: Vec<Vec<u8>> = tokens.map(|token| token.to_vec()).collect();
+        let mut datalen = None;
+        // Only VA carries a datalen token; ME responses echo the key, which
+        // may itself start with a digit.
+        if rc == ReturnCode::Va {
+            if flags.is_empty() {
+                return Err(ServerError::BadResponse(Cow::Borrowed("VA response missing data length")).into());
+            }
+            let token = flags.remove(0);
+            datalen = Some(std::str::from_utf8(&token)?.parse::<usize>()?);
+        }
+        Ok(MetaResponse {
+            rc,
+            datalen,
+            flags,
+            value: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_roundtrip() {
+        let cases: &[&[u8]] = &[b"", b"f", b"fo", b"foo", b"foob", b"fooba", b"foobar", b"\x00\xff\x10"];
+        for case in cases {
+            let encoded = base64_encode(case);
+            assert_eq!(base64_decode(&encoded).unwrap(), case.to_vec());
+        }
+        assert_eq!(base64_encode(b"foobar"), b"Zm9vYmFy".to_vec());
+        assert_eq!(base64_encode(b"foob"), b"Zm9vYg==".to_vec());
+        assert!(base64_decode(b"Zm9vY").is_err());
+        assert!(base64_decode(b"Zm=vYg==").is_err());
+    }
+
+    #[test]
+    fn encode_get() {
+        let mut command = MetaCommand::new(MetaOp::Get, "foo");
+        command.flags = vec![b"v".to_vec(), b"t".to_vec()];
+        assert_eq!(command.encode().unwrap(), b"mg foo v t\r\n".to_vec());
+    }
+
+    #[test]
+    fn encode_set_with_value() {
+        let mut command = MetaCommand::new(MetaOp::Set, "foo");
+        command.flags = vec![b"T60".to_vec()];
+        command.value = Some(b"bar".to_vec());
+        assert_eq!(command.encode().unwrap(), b"ms foo 3 T60\r\nbar\r\n".to_vec());
+    }
+
+    #[test]
+    fn encode_noop() {
+        let command = MetaCommand::new(MetaOp::Noop, "");
+        assert_eq!(command.encode().unwrap(), b"mn\r\n".to_vec());
+    }
+
+    #[test]
+    fn encode_binary_key_adds_base64_flag() {
+        let mut command = MetaCommand::new(MetaOp::Get, b"a key".to_vec());
+        command.flags = vec![b"v".to_vec()];
+        assert_eq!(command.encode().unwrap(), b"mg YSBrZXk= v b\r\n".to_vec());
+    }
+
+    #[test]
+    fn encode_rejects_bad_keys() {
+        assert!(MetaCommand::new(MetaOp::Get, "").encode().is_err());
+        let long_key = vec![b'x'; MAX_KEY_LENGTH + 1];
+        assert!(MetaCommand::new(MetaOp::Get, long_key).encode().is_err());
+        // The base64 form is what must fit in 250 bytes.
+        let binary_key = vec![b' '; 200];
+        assert!(MetaCommand::new(MetaOp::Get, binary_key).encode().is_err());
+    }
+
+    #[test]
+    fn parse_header_hd_with_flags() {
+        let response = MetaResponse::parse_header(b"HD c1234 t42").unwrap();
+        assert_eq!(response.rc, ReturnCode::Hd);
+        assert_eq!(response.datalen, None);
+        assert_eq!(response.flags, vec![b"c1234".to_vec(), b"t42".to_vec()]);
+    }
+
+    #[test]
+    fn parse_header_va_datalen() {
+        let response = MetaResponse::parse_header(b"VA 5 f0 c1").unwrap();
+        assert_eq!(response.rc, ReturnCode::Va);
+        assert_eq!(response.datalen, Some(5));
+        assert_eq!(response.flags, vec![b"f0".to_vec(), b"c1".to_vec()]);
+        assert!(MetaResponse::parse_header(b"VA").is_err());
+    }
+
+    #[test]
+    fn parse_header_errors() {
+        assert!(matches!(
+            MetaResponse::parse_header(b"ERROR"),
+            Err(MemcacheError::CommandError(CommandError::InvalidCommand))
+        ));
+        assert!(matches!(
+            MetaResponse::parse_header(b"CLIENT_ERROR bad data chunk"),
+            Err(MemcacheError::ClientError(_))
+        ));
+        assert!(matches!(
+            MetaResponse::parse_header(b"SERVER_ERROR out of memory"),
+            Err(MemcacheError::ServerError(_))
+        ));
+        assert!(MetaResponse::parse_header(b"XX").is_err());
+        assert!(MetaResponse::parse_header(b"").is_err());
+    }
+}

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -1,0 +1,50 @@
+/*!
+Experimental client built on the memcached
+[meta protocol](https://github.com/memcached/memcached/blob/master/doc/protocol.txt).
+
+Everything in this module is experimental and may change without notice.
+
+For now only the wire layer is implemented, split in two:
+
+- [`MetaCommand`] / [`MetaResponse`]: framing — request assembly and response
+  header parsing, including automatic base64 encoding of binary keys.
+- `build_*` / `parse_*` and the `*Options` structs: a typed 1:1 mapping of the
+  protocol where every option field corresponds to exactly one protocol flag.
+  No serialization and no semantic interpretation happens at this level.
+
+Transports are TCP only: [`MetaConnection`] (blocking) and
+[`AsyncMetaConnection`] (tokio, behind the `tokio` feature). A high-level
+client with serialization, typed results and pipelining will be layered on
+top later.
+
+# Example
+
+```no_run
+use memcache::exp::{build_get, parse_meta_result, GetOptions, MetaConnection};
+
+let mut connection = MetaConnection::connect("127.0.0.1:11211").unwrap();
+let command = build_get("foo", &GetOptions::default()).unwrap();
+let response = connection.execute(&command).unwrap();
+let result = parse_meta_result(response).unwrap();
+if result.ok() {
+    println!("value: {:?}", result.value);
+}
+```
+*/
+
+mod connection;
+mod meta_api;
+mod meta_command;
+
+#[cfg(feature = "tokio")]
+mod async_connection;
+
+#[cfg(feature = "tokio")]
+pub use async_connection::AsyncMetaConnection;
+pub use connection::MetaConnection;
+pub use meta_api::{
+    ArithmeticMode, ArithmeticOptions, DeleteOptions, GetOptions, MetaCommandResult, SetMode, SetOptions,
+    build_arithmetic, build_debug, build_delete, build_get, build_noop, build_set, parse_debug_result,
+    parse_meta_result,
+};
+pub use meta_command::{MAX_KEY_LENGTH, MetaCommand, MetaOp, MetaResponse, ReturnCode};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ extern crate url;
 mod client;
 mod connection;
 mod error;
+pub mod exp;
 mod protocol;
 mod stream;
 mod value;


### PR DESCRIPTION
Add an experimental `exp` module implementing the wire layer of the memcached meta protocol, as a foundation for a future meta-based client.

- `MetaCommand` / `MetaResponse`: request framing and response header parsing, with automatic base64 encoding for binary keys
- Typed builders (`build_get` / `build_set` / `build_delete` / `build_arithmetic` / `build_noop` / `build_debug`) and result parsers, where every option field maps to exactly one protocol flag
- TCP transports: blocking `MetaConnection`, plus `AsyncMetaConnection` behind a new optional `tokio` feature