### PR TITLE
Add semantic layer and clients to exp module

### DIFF
--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -1,0 +1,75 @@
+//! Tokio single-server client over the semantic layer.
+
+use std::collections::HashMap;
+
+use tokio::net::ToSocketAddrs;
+
+use crate::error::{MemcacheError, ServerError};
+
+use super::async_connection::AsyncMetaConnection;
+use super::core;
+use super::meta_api::{MetaCommandResult, build_debug, build_noop, parse_debug_result, parse_meta_result};
+use super::meta_command::{MetaCommand, ReturnCode};
+use super::operation::{Arithmetic, Delete, Get, Set};
+use super::result::{ArithmeticResult, GetResult, MutationResult};
+
+/// The async counterpart of [`MetaClient`](super::MetaClient); same
+/// semantics over a tokio connection.
+pub struct AsyncMetaClient {
+    connection: AsyncMetaConnection,
+}
+
+impl AsyncMetaClient {
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> Result<AsyncMetaClient, MemcacheError> {
+        Ok(AsyncMetaClient::from_connection(
+            AsyncMetaConnection::connect(addr).await?,
+        ))
+    }
+
+    pub fn from_connection(connection: AsyncMetaConnection) -> AsyncMetaClient {
+        AsyncMetaClient { connection }
+    }
+
+    async fn run(&mut self, command: &MetaCommand) -> Result<MetaCommandResult, MemcacheError> {
+        parse_meta_result(self.connection.execute(command).await?)
+    }
+
+    pub async fn get(&mut self, operation: &Get) -> Result<GetResult, MemcacheError> {
+        let command = core::prepare_get(operation)?;
+        let wire = self.run(&command).await?;
+        core::parse_get(operation, wire)
+    }
+
+    pub async fn set(&mut self, operation: &Set) -> Result<MutationResult, MemcacheError> {
+        let command = core::prepare_set(operation)?;
+        let wire = self.run(&command).await?;
+        core::parse_set(operation, wire)
+    }
+
+    pub async fn delete(&mut self, operation: &Delete) -> Result<MutationResult, MemcacheError> {
+        let command = core::prepare_delete(operation)?;
+        let wire = self.run(&command).await?;
+        core::parse_delete(operation, wire)
+    }
+
+    pub async fn arithmetic(&mut self, operation: &Arithmetic) -> Result<ArithmeticResult, MemcacheError> {
+        let command = core::prepare_arithmetic(operation)?;
+        let wire = self.run(&command).await?;
+        core::parse_arithmetic(operation, wire)
+    }
+
+    /// Round-trip an `mn` no-op; useful as a connection health check.
+    pub async fn noop(&mut self) -> Result<(), MemcacheError> {
+        let response = self.connection.execute(&build_noop()).await?;
+        if response.rc != ReturnCode::Mn {
+            return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
+        }
+        Ok(())
+    }
+
+    /// Fetch `me` debug fields for a key; `None` on a miss.
+    pub async fn debug(&mut self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
+        let response = self.connection.execute(&build_debug(key)?).await?;
+        parse_debug_result(&response)
+    }
+}

--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -7,14 +7,24 @@ use tokio::net::ToSocketAddrs;
 use crate::error::{MemcacheError, ServerError};
 
 use super::async_connection::AsyncMetaConnection;
-use super::core;
-use super::meta_api::{MetaCommandResult, build_debug, build_noop, parse_debug_result, parse_meta_result};
-use super::meta_command::{MetaCommand, ReturnCode};
+use super::core::Operation;
+use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
+use super::meta_command::ReturnCode;
 use super::operation::{Arithmetic, Delete, Get, Set};
-use super::result::{ArithmeticResult, GetResult, MutationResult};
+use super::request::Request;
 
-/// The async counterpart of [`MetaClient`](super::MetaClient); same
-/// semantics over a tokio connection.
+/// The async counterpart of [`MetaClient`](super::MetaClient); the same
+/// request-builder surface over a tokio connection.
+///
+/// ```no_run
+/// # use memcache::exp::AsyncMetaClient;
+/// # async fn example() -> Result<(), memcache::MemcacheError> {
+/// let mut client = AsyncMetaClient::connect("127.0.0.1:11211").await?;
+/// client.set("foo", "bar").ttl(60).send().await?;
+/// let result = client.get("foo").send().await?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct AsyncMetaClient {
     connection: AsyncMetaConnection,
 }
@@ -30,32 +40,41 @@ impl AsyncMetaClient {
         AsyncMetaClient { connection }
     }
 
-    async fn run(&mut self, command: &MetaCommand) -> Result<MetaCommandResult, MemcacheError> {
-        parse_meta_result(self.connection.execute(command).await?)
+    /// Read a key.
+    pub fn get(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Get> {
+        Request::new(self, Get::new(key))
     }
 
-    pub async fn get(&mut self, operation: &Get) -> Result<GetResult, MemcacheError> {
-        let command = core::prepare_get(operation)?;
-        let wire = self.run(&command).await?;
-        core::parse_get(operation, wire)
+    /// Store a value under a key.
+    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Set> {
+        Request::new(self, Set::new(key, value))
     }
 
-    pub async fn set(&mut self, operation: &Set) -> Result<MutationResult, MemcacheError> {
-        let command = core::prepare_set(operation)?;
-        let wire = self.run(&command).await?;
-        core::parse_set(operation, wire)
+    /// Delete a key.
+    pub fn delete(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Delete> {
+        Request::new(self, Delete::new(key))
     }
 
-    pub async fn delete(&mut self, operation: &Delete) -> Result<MutationResult, MemcacheError> {
-        let command = core::prepare_delete(operation)?;
-        let wire = self.run(&command).await?;
-        core::parse_delete(operation, wire)
+    /// Increment a counter (delta defaults to 1).
+    pub fn increment(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Arithmetic> {
+        Request::new(self, Arithmetic::new(key))
     }
 
-    pub async fn arithmetic(&mut self, operation: &Arithmetic) -> Result<ArithmeticResult, MemcacheError> {
-        let command = core::prepare_arithmetic(operation)?;
-        let wire = self.run(&command).await?;
-        core::parse_arithmetic(operation, wire)
+    /// Decrement a counter (delta defaults to 1); saturates at zero.
+    pub fn decrement(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Arithmetic> {
+        let operation = Arithmetic {
+            mode: ArithmeticMode::Decrement,
+            ..Arithmetic::new(key)
+        };
+        Request::new(self, operation)
+    }
+
+    /// Run a standalone operation value; [`send`](Request::send) is sugar
+    /// for this.
+    pub async fn run<O: Operation>(&mut self, operation: O) -> Result<O::Output, MemcacheError> {
+        let command = operation.prepare()?;
+        let wire = parse_meta_result(self.connection.execute(&command).await?)?;
+        operation.parse(wire)
     }
 
     /// Round-trip an `mn` no-op; useful as a connection health check.
@@ -71,5 +90,13 @@ impl AsyncMetaClient {
     pub async fn debug(&mut self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
         let response = self.connection.execute(&build_debug(key)?).await?;
         parse_debug_result(&response)
+    }
+}
+
+impl<'a, O: Operation> Request<'a, AsyncMetaClient, O> {
+    /// Execute the request and return its typed result.
+    pub async fn send(self) -> Result<O::Output, MemcacheError> {
+        let Request { client, operation } = self;
+        client.run(operation).await
     }
 }

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -6,17 +6,24 @@ use std::net::ToSocketAddrs;
 use crate::error::{MemcacheError, ServerError};
 
 use super::connection::MetaConnection;
-use super::core;
-use super::meta_api::{MetaCommandResult, build_debug, build_noop, parse_debug_result, parse_meta_result};
-use super::meta_command::{MetaCommand, ReturnCode};
+use super::core::Operation;
+use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
+use super::meta_command::ReturnCode;
 use super::operation::{Arithmetic, Delete, Get, Set};
-use super::result::{ArithmeticResult, GetResult, MutationResult};
+use super::request::Request;
 
 /// A blocking meta protocol client for a single server.
 ///
-/// Operations go in, typed results come out; values are raw bytes.
-/// Serialization, multi-server routing and pipelining are not implemented
-/// yet.
+/// The verbs return lazy [`Request`] builders; chain options and finish with
+/// [`send`](Request::send). Values are raw bytes. Serialization,
+/// multi-server routing and batching are not implemented yet.
+///
+/// ```no_run
+/// # use memcache::exp::MetaClient;
+/// let mut client = MetaClient::connect("127.0.0.1:11211").unwrap();
+/// client.set("foo", "bar").ttl(60).send().unwrap();
+/// let result = client.get("foo").send().unwrap();
+/// ```
 pub struct MetaClient {
     connection: MetaConnection,
 }
@@ -30,28 +37,41 @@ impl MetaClient {
         MetaClient { connection }
     }
 
-    fn run(&mut self, command: &MetaCommand) -> Result<MetaCommandResult, MemcacheError> {
-        parse_meta_result(self.connection.execute(command)?)
+    /// Read a key.
+    pub fn get(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Get> {
+        Request::new(self, Get::new(key))
     }
 
-    pub fn get(&mut self, operation: &Get) -> Result<GetResult, MemcacheError> {
-        let command = core::prepare_get(operation)?;
-        core::parse_get(operation, self.run(&command)?)
+    /// Store a value under a key.
+    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Set> {
+        Request::new(self, Set::new(key, value))
     }
 
-    pub fn set(&mut self, operation: &Set) -> Result<MutationResult, MemcacheError> {
-        let command = core::prepare_set(operation)?;
-        core::parse_set(operation, self.run(&command)?)
+    /// Delete a key.
+    pub fn delete(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Delete> {
+        Request::new(self, Delete::new(key))
     }
 
-    pub fn delete(&mut self, operation: &Delete) -> Result<MutationResult, MemcacheError> {
-        let command = core::prepare_delete(operation)?;
-        core::parse_delete(operation, self.run(&command)?)
+    /// Increment a counter (delta defaults to 1).
+    pub fn increment(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Arithmetic> {
+        Request::new(self, Arithmetic::new(key))
     }
 
-    pub fn arithmetic(&mut self, operation: &Arithmetic) -> Result<ArithmeticResult, MemcacheError> {
-        let command = core::prepare_arithmetic(operation)?;
-        core::parse_arithmetic(operation, self.run(&command)?)
+    /// Decrement a counter (delta defaults to 1); saturates at zero.
+    pub fn decrement(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Arithmetic> {
+        let operation = Arithmetic {
+            mode: ArithmeticMode::Decrement,
+            ..Arithmetic::new(key)
+        };
+        Request::new(self, operation)
+    }
+
+    /// Run a standalone operation value; [`send`](Request::send) is sugar
+    /// for this.
+    pub fn run<O: Operation>(&mut self, operation: O) -> Result<O::Output, MemcacheError> {
+        let command = operation.prepare()?;
+        let wire = parse_meta_result(self.connection.execute(&command)?)?;
+        operation.parse(wire)
     }
 
     /// Round-trip an `mn` no-op; useful as a connection health check.
@@ -70,13 +90,20 @@ impl MetaClient {
     }
 }
 
+impl<'a, O: Operation> Request<'a, MetaClient, O> {
+    /// Execute the request and return its typed result.
+    pub fn send(self) -> Result<O::Output, MemcacheError> {
+        let Request { client, operation } = self;
+        client.run(operation)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::{BufRead, BufReader, Read, Write};
     use std::net::{SocketAddr, TcpListener};
     use std::thread::JoinHandle;
 
-    use super::super::meta_api::SetMode;
     use super::super::result::{GetStatus, MutationStatus};
     use super::*;
 
@@ -119,25 +146,20 @@ mod tests {
         ]);
         let mut client = MetaClient::connect(addr).unwrap();
 
-        let stored = client.set(&Set::new("foo", "bar")).unwrap();
+        let stored = client.set("foo", "bar").send().unwrap();
         assert_eq!(stored.status, MutationStatus::Stored);
 
-        let fetched = client.get(&Get::new("foo")).unwrap();
+        let fetched = client.get("foo").send().unwrap();
         assert_eq!(fetched.status, GetStatus::Hit);
         assert_eq!(fetched.value.as_deref(), Some(&b"bar"[..]));
 
-        let added = client
-            .set(&Set {
-                mode: SetMode::Add,
-                ..Set::new("foo", "baz")
-            })
-            .unwrap();
+        let added = client.set("foo", "baz").add().send().unwrap();
         assert_eq!(added.status, MutationStatus::AlreadyExists);
 
-        let counter = client.arithmetic(&Arithmetic::new("counter")).unwrap();
+        let counter = client.increment("counter").delta(2).send().unwrap();
         assert_eq!(counter.value, Some(42));
 
-        let deleted = client.delete(&Delete::new("foo")).unwrap();
+        let deleted = client.delete("foo").send().unwrap();
         assert!(deleted.stored());
 
         client.noop().unwrap();
@@ -146,8 +168,24 @@ mod tests {
         assert_eq!(requests[0], b"ms foo 3\r\n".to_vec());
         assert_eq!(requests[1], b"mg foo v f\r\n".to_vec());
         assert_eq!(requests[2], b"ms foo 3 ME\r\n".to_vec());
-        assert_eq!(requests[3], b"ma counter v D1\r\n".to_vec());
+        assert_eq!(requests[3], b"ma counter v D2\r\n".to_vec());
         assert_eq!(requests[4], b"md foo\r\n".to_vec());
         assert_eq!(requests[5], b"mn\r\n".to_vec());
+    }
+
+    #[test]
+    fn run_executes_standalone_operations() {
+        let (addr, server) = scripted_server(vec![b"HD\r\n", b"VA 1\r\n1\r\n"]);
+        let mut client = MetaClient::connect(addr).unwrap();
+
+        let operation = client.set("foo", "bar").ttl(60).into_operation();
+        assert!(client.run(operation).unwrap().stored());
+
+        let decremented = client.decrement("counter").send().unwrap();
+        assert_eq!(decremented.value, Some(1));
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests[0], b"ms foo 3 T60\r\n".to_vec());
+        assert_eq!(requests[1], b"ma counter MD v D1\r\n".to_vec());
     }
 }

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -1,0 +1,153 @@
+//! Blocking single-server client over the semantic layer.
+
+use std::collections::HashMap;
+use std::net::ToSocketAddrs;
+
+use crate::error::{MemcacheError, ServerError};
+
+use super::connection::MetaConnection;
+use super::core;
+use super::meta_api::{MetaCommandResult, build_debug, build_noop, parse_debug_result, parse_meta_result};
+use super::meta_command::{MetaCommand, ReturnCode};
+use super::operation::{Arithmetic, Delete, Get, Set};
+use super::result::{ArithmeticResult, GetResult, MutationResult};
+
+/// A blocking meta protocol client for a single server.
+///
+/// Operations go in, typed results come out; values are raw bytes.
+/// Serialization, multi-server routing and pipelining are not implemented
+/// yet.
+pub struct MetaClient {
+    connection: MetaConnection,
+}
+
+impl MetaClient {
+    pub fn connect<A: ToSocketAddrs>(addr: A) -> Result<MetaClient, MemcacheError> {
+        Ok(MetaClient::from_connection(MetaConnection::connect(addr)?))
+    }
+
+    pub fn from_connection(connection: MetaConnection) -> MetaClient {
+        MetaClient { connection }
+    }
+
+    fn run(&mut self, command: &MetaCommand) -> Result<MetaCommandResult, MemcacheError> {
+        parse_meta_result(self.connection.execute(command)?)
+    }
+
+    pub fn get(&mut self, operation: &Get) -> Result<GetResult, MemcacheError> {
+        let command = core::prepare_get(operation)?;
+        core::parse_get(operation, self.run(&command)?)
+    }
+
+    pub fn set(&mut self, operation: &Set) -> Result<MutationResult, MemcacheError> {
+        let command = core::prepare_set(operation)?;
+        core::parse_set(operation, self.run(&command)?)
+    }
+
+    pub fn delete(&mut self, operation: &Delete) -> Result<MutationResult, MemcacheError> {
+        let command = core::prepare_delete(operation)?;
+        core::parse_delete(operation, self.run(&command)?)
+    }
+
+    pub fn arithmetic(&mut self, operation: &Arithmetic) -> Result<ArithmeticResult, MemcacheError> {
+        let command = core::prepare_arithmetic(operation)?;
+        core::parse_arithmetic(operation, self.run(&command)?)
+    }
+
+    /// Round-trip an `mn` no-op; useful as a connection health check.
+    pub fn noop(&mut self) -> Result<(), MemcacheError> {
+        let response = self.connection.execute(&build_noop())?;
+        if response.rc != ReturnCode::Mn {
+            return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
+        }
+        Ok(())
+    }
+
+    /// Fetch `me` debug fields for a key; `None` on a miss.
+    pub fn debug(&mut self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
+        let response = self.connection.execute(&build_debug(key)?)?;
+        parse_debug_result(&response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{SocketAddr, TcpListener};
+    use std::thread::JoinHandle;
+
+    use super::super::meta_api::SetMode;
+    use super::super::result::{GetStatus, MutationStatus};
+    use super::*;
+
+    /// A single-connection server that answers each request with the next
+    /// scripted response and records the request headers it saw.
+    fn scripted_server(responses: Vec<&'static [u8]>) -> (SocketAddr, JoinHandle<Vec<Vec<u8>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut requests = Vec::new();
+            for response in responses {
+                let mut header = Vec::new();
+                reader.read_until(b'\n', &mut header).unwrap();
+                // Consume the data block of an ms request.
+                if header.starts_with(b"ms ") {
+                    let line = String::from_utf8(header.clone()).unwrap();
+                    let datalen: usize = line.split_whitespace().nth(2).unwrap().parse().unwrap();
+                    let mut value = vec![0u8; datalen + 2];
+                    reader.read_exact(&mut value).unwrap();
+                }
+                requests.push(header);
+                reader.get_mut().write_all(response).unwrap();
+            }
+            requests
+        });
+        (addr, handle)
+    }
+
+    #[test]
+    fn client_roundtrip() {
+        let (addr, server) = scripted_server(vec![
+            b"HD\r\n",
+            b"VA 3 f0\r\nbar\r\n",
+            b"NS\r\n",
+            b"VA 2\r\n42\r\n",
+            b"HD\r\n",
+            b"MN\r\n",
+        ]);
+        let mut client = MetaClient::connect(addr).unwrap();
+
+        let stored = client.set(&Set::new("foo", "bar")).unwrap();
+        assert_eq!(stored.status, MutationStatus::Stored);
+
+        let fetched = client.get(&Get::new("foo")).unwrap();
+        assert_eq!(fetched.status, GetStatus::Hit);
+        assert_eq!(fetched.value.as_deref(), Some(&b"bar"[..]));
+
+        let added = client
+            .set(&Set {
+                mode: SetMode::Add,
+                ..Set::new("foo", "baz")
+            })
+            .unwrap();
+        assert_eq!(added.status, MutationStatus::AlreadyExists);
+
+        let counter = client.arithmetic(&Arithmetic::new("counter")).unwrap();
+        assert_eq!(counter.value, Some(42));
+
+        let deleted = client.delete(&Delete::new("foo")).unwrap();
+        assert!(deleted.stored());
+
+        client.noop().unwrap();
+
+        let requests = server.join().unwrap();
+        assert_eq!(requests[0], b"ms foo 3\r\n".to_vec());
+        assert_eq!(requests[1], b"mg foo v f\r\n".to_vec());
+        assert_eq!(requests[2], b"ms foo 3 ME\r\n".to_vec());
+        assert_eq!(requests[3], b"ma counter v D1\r\n".to_vec());
+        assert_eq!(requests[4], b"md foo\r\n".to_vec());
+        assert_eq!(requests[5], b"mn\r\n".to_vec());
+    }
+}

--- a/src/exp/core.rs
+++ b/src/exp/core.rs
@@ -1,0 +1,438 @@
+//! Transport-independent semantic core: turns operations into wire commands
+//! and pairs wire results back with their operations to produce typed
+//! results. Both clients (blocking and tokio) are thin I/O loops around
+//! these functions, and the future pipeline executor will reuse them.
+
+use std::borrow::Cow;
+
+use crate::error::{ClientError, MemcacheError, ServerError};
+
+use super::meta_api::{
+    ArithmeticOptions, DeleteOptions, GetOptions, MetaCommandResult, SetMode, SetOptions, build_arithmetic,
+    build_delete, build_get, build_set,
+};
+use super::meta_command::{MetaCommand, ReturnCode};
+use super::operation::{Arithmetic, Delete, Get, Set};
+use super::result::{
+    ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, ValueState,
+};
+
+fn invalid<T>(message: &'static str) -> Result<T, MemcacheError> {
+    Err(ClientError::Error(Cow::Borrowed(message)).into())
+}
+
+fn unexpected<T>(message: &'static str) -> Result<T, MemcacheError> {
+    Err(ServerError::BadResponse(Cow::Borrowed(message)).into())
+}
+
+pub(crate) fn prepare_get(operation: &Get) -> Result<MetaCommand, MemcacheError> {
+    if operation.lease_ttl == Some(0) {
+        return invalid("lease_ttl must be >= 1");
+    }
+    if operation.refresh_before == Some(0) {
+        return invalid("refresh_before must be >= 1");
+    }
+    if operation.refresh_before.is_some() && operation.lease_ttl.is_none() {
+        return invalid("refresh_before requires lease_ttl");
+    }
+    if operation.unless_cas.is_some() && !operation.value {
+        return invalid("unless_cas requires a value read");
+    }
+    // Lease and conditional reads need the CAS to act on the result.
+    let return_cas = operation.meta.cas || operation.lease_ttl.is_some() || operation.unless_cas.is_some();
+    let options = GetOptions {
+        value: operation.value,
+        return_client_flags: true,
+        return_cas,
+        return_ttl: operation.meta.ttl,
+        return_size: operation.meta.size,
+        return_last_access: operation.meta.last_access,
+        return_hit_before: operation.meta.hit_before,
+        no_lru_bump: operation.no_lru_bump,
+        touch: operation.touch,
+        vivify_ttl: operation.lease_ttl,
+        recache_ttl: operation.refresh_before,
+        unless_cas: operation.unless_cas,
+        ..GetOptions::default()
+    };
+    build_get(operation.key.clone(), &options)
+}
+
+pub(crate) fn prepare_set(operation: &Set) -> Result<MetaCommand, MemcacheError> {
+    if operation.vivify_ttl == Some(0) {
+        return invalid("vivify_ttl must be >= 1");
+    }
+    let options = SetOptions {
+        ttl: operation.ttl,
+        mode: operation.mode,
+        compare_cas: operation.compare_cas,
+        new_cas: operation.version,
+        vivify_ttl: operation.vivify_ttl,
+        return_cas: operation.return_cas,
+        ..SetOptions::default()
+    };
+    build_set(operation.key.clone(), operation.value.clone(), &options)
+}
+
+pub(crate) fn prepare_delete(operation: &Delete) -> Result<MetaCommand, MemcacheError> {
+    if operation.stale_for.is_some() && !operation.invalidate {
+        return invalid("stale_for is only valid for invalidate");
+    }
+    let options = DeleteOptions {
+        compare_cas: operation.compare_cas,
+        invalidate: operation.invalidate,
+        ttl: operation.stale_for,
+        ..DeleteOptions::default()
+    };
+    build_delete(operation.key.clone(), &options)
+}
+
+pub(crate) fn prepare_arithmetic(operation: &Arithmetic) -> Result<MetaCommand, MemcacheError> {
+    if operation.initial_ttl == Some(0) {
+        return invalid("initial_ttl must be >= 1");
+    }
+    if operation.initial_ttl.is_some() && operation.initial.is_none() {
+        return invalid("initial_ttl requires initial");
+    }
+    let options = ArithmeticOptions {
+        delta: Some(operation.delta),
+        mode: operation.mode,
+        initial: operation.initial,
+        initial_ttl: operation.initial_ttl,
+        ttl: operation.ttl,
+        compare_cas: operation.compare_cas,
+        new_cas: operation.version,
+        return_value: true,
+        return_ttl: operation.return_ttl,
+        return_cas: operation.return_cas,
+        ..ArithmeticOptions::default()
+    };
+    build_arithmetic(operation.key.clone(), &options)
+}
+
+fn mutation_status(is_add: bool, rc: ReturnCode) -> Result<MutationStatus, MemcacheError> {
+    match rc {
+        ReturnCode::Hd | ReturnCode::Va => Ok(MutationStatus::Stored),
+        ReturnCode::Ex => Ok(MutationStatus::CasMismatch),
+        ReturnCode::Nf => Ok(MutationStatus::NotFound),
+        ReturnCode::Ns => Ok(if is_add {
+            MutationStatus::AlreadyExists
+        } else {
+            MutationStatus::NotFound
+        }),
+        _ => unexpected("unexpected mutation response"),
+    }
+}
+
+pub(crate) fn parse_get(operation: &Get, wire: MetaCommandResult) -> Result<GetResult, MemcacheError> {
+    if wire.rc == ReturnCode::En {
+        return Ok(GetResult {
+            key: operation.key.clone(),
+            status: GetStatus::Miss,
+            value: None,
+            item: ItemMeta::default(),
+            value_state: ValueState::Missing,
+            lease_state: LeaseState::None,
+        });
+    }
+    if wire.rc != ReturnCode::Va && wire.rc != ReturnCode::Hd {
+        return unexpected("unexpected get response");
+    }
+    let item = ItemMeta {
+        cas: wire.cas,
+        ttl: wire.ttl,
+        size: wire.size,
+        last_access: wire.last_access,
+        hit_before: wire.hit_before,
+    };
+    let lease_state = if wire.won {
+        LeaseState::Granted
+    } else if wire.busy {
+        LeaseState::Busy
+    } else {
+        LeaseState::None
+    };
+    // A vivified item is an empty non-stale value plus a lease flag: nobody
+    // has stored real data yet.
+    let placeholder = !wire.stale && wire.value.as_deref() == Some(b"") && lease_state != LeaseState::None;
+    let value_state = if wire.stale {
+        ValueState::Stale
+    } else if placeholder {
+        ValueState::Missing
+    } else {
+        ValueState::Fresh
+    };
+    let (status, value) = if placeholder {
+        // With a lease request the placeholder is this client's own vivify:
+        // report a miss and let the caller fill it. Without one, another
+        // client is filling it.
+        if operation.lease_ttl.is_some() {
+            (GetStatus::Miss, None)
+        } else {
+            (GetStatus::Pending, None)
+        }
+    } else if wire.rc == ReturnCode::Hd && operation.unless_cas.is_some() {
+        (GetStatus::Unchanged, None)
+    } else {
+        let value = if wire.rc == ReturnCode::Va { wire.value } else { None };
+        (GetStatus::Hit, value)
+    };
+    Ok(GetResult {
+        key: operation.key.clone(),
+        status,
+        value,
+        item,
+        value_state,
+        lease_state,
+    })
+}
+
+pub(crate) fn parse_set(operation: &Set, wire: MetaCommandResult) -> Result<MutationResult, MemcacheError> {
+    Ok(MutationResult {
+        key: operation.key.clone(),
+        status: mutation_status(operation.mode == SetMode::Add, wire.rc)?,
+        cas: wire.cas,
+    })
+}
+
+pub(crate) fn parse_delete(operation: &Delete, wire: MetaCommandResult) -> Result<MutationResult, MemcacheError> {
+    Ok(MutationResult {
+        key: operation.key.clone(),
+        status: mutation_status(false, wire.rc)?,
+        cas: wire.cas,
+    })
+}
+
+pub(crate) fn parse_arithmetic(
+    operation: &Arithmetic,
+    wire: MetaCommandResult,
+) -> Result<ArithmeticResult, MemcacheError> {
+    let status = mutation_status(false, wire.rc)?;
+    let value = match (&wire.value, wire.rc) {
+        (Some(value), ReturnCode::Va) if !value.is_empty() => Some(std::str::from_utf8(value)?.parse::<u64>()?),
+        _ => None,
+    };
+    Ok(ArithmeticResult {
+        key: operation.key.clone(),
+        status,
+        value,
+        item: ItemMeta {
+            cas: wire.cas,
+            ttl: wire.ttl,
+            ..ItemMeta::default()
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::meta_api::parse_meta_result;
+    use super::super::meta_command::MetaResponse;
+    use super::super::operation::Meta;
+    use super::*;
+
+    fn wire(header: &[u8], value: Option<&[u8]>) -> MetaCommandResult {
+        let mut response = MetaResponse::parse_header(header).unwrap();
+        response.value = value.map(|value| value.to_vec());
+        parse_meta_result(response).unwrap()
+    }
+
+    #[test]
+    fn prepare_get_wire_format() {
+        let command = prepare_get(&Get::new("foo")).unwrap();
+        assert_eq!(command.encode().unwrap(), b"mg foo v f\r\n".to_vec());
+
+        let operation = Get {
+            meta: Meta {
+                cas: true,
+                ttl: true,
+                ..Meta::NONE
+            },
+            touch: Some(60),
+            ..Get::new("foo")
+        };
+        let command = prepare_get(&operation).unwrap();
+        assert_eq!(command.encode().unwrap(), b"mg foo v f c t T60\r\n".to_vec());
+
+        // A lease read implies the CAS even when not requested.
+        let operation = Get {
+            lease_ttl: Some(30),
+            ..Get::new("foo")
+        };
+        let command = prepare_get(&operation).unwrap();
+        assert_eq!(command.encode().unwrap(), b"mg foo v f c N30\r\n".to_vec());
+    }
+
+    #[test]
+    fn prepare_get_validation() {
+        assert!(
+            prepare_get(&Get {
+                lease_ttl: Some(0),
+                ..Get::new("k")
+            })
+            .is_err()
+        );
+        assert!(
+            prepare_get(&Get {
+                refresh_before: Some(5),
+                ..Get::new("k")
+            })
+            .is_err()
+        );
+        assert!(
+            prepare_get(&Get {
+                unless_cas: Some(1),
+                value: false,
+                ..Get::new("k")
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn prepare_set_wire_format() {
+        let command = prepare_set(&Set::new("foo", "bar")).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ms foo 3\r\nbar\r\n".to_vec());
+
+        let operation = Set {
+            mode: SetMode::Add,
+            ttl: Some(60),
+            return_cas: true,
+            ..Set::new("foo", "bar")
+        };
+        let command = prepare_set(&operation).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ms foo 3 ME c T60\r\nbar\r\n".to_vec());
+    }
+
+    #[test]
+    fn prepare_delete_validation() {
+        let command = prepare_delete(&Delete::new("foo")).unwrap();
+        assert_eq!(command.encode().unwrap(), b"md foo\r\n".to_vec());
+        assert!(
+            prepare_delete(&Delete {
+                stale_for: Some(30),
+                ..Delete::new("foo")
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn prepare_arithmetic_validation() {
+        let command = prepare_arithmetic(&Arithmetic::new("counter")).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ma counter v D1\r\n".to_vec());
+        assert!(
+            prepare_arithmetic(&Arithmetic {
+                initial_ttl: Some(60),
+                ..Arithmetic::new("counter")
+            })
+            .is_err()
+        );
+        assert!(
+            prepare_arithmetic(&Arithmetic {
+                initial: Some(0),
+                ..Arithmetic::new("counter")
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn parse_get_hit_and_miss() {
+        let operation = Get::new("foo");
+        let result = parse_get(&operation, wire(b"VA 3 f0 c42", Some(b"bar"))).unwrap();
+        assert_eq!(result.status, GetStatus::Hit);
+        assert!(result.hit());
+        assert_eq!(result.value.as_deref(), Some(&b"bar"[..]));
+        assert_eq!(result.item.cas, Some(42));
+        assert_eq!(result.value_state, ValueState::Fresh);
+
+        let result = parse_get(&operation, wire(b"EN", None)).unwrap();
+        assert_eq!(result.status, GetStatus::Miss);
+        assert_eq!(result.value, None);
+
+        assert!(parse_get(&operation, wire(b"NS", None)).is_err());
+    }
+
+    #[test]
+    fn parse_get_lease_placeholder() {
+        // Our own vivify: empty placeholder with the won flag is a miss with
+        // a granted lease.
+        let operation = Get {
+            lease_ttl: Some(30),
+            ..Get::new("foo")
+        };
+        let result = parse_get(&operation, wire(b"VA 0 c7 W", Some(b""))).unwrap();
+        assert_eq!(result.status, GetStatus::Miss);
+        assert!(result.won_lease());
+        assert_eq!(result.value_state, ValueState::Missing);
+
+        // Someone else's placeholder: pending.
+        let result = parse_get(&Get::new("foo"), wire(b"VA 0 c7 Z", Some(b""))).unwrap();
+        assert_eq!(result.status, GetStatus::Pending);
+        assert!(result.lease_busy());
+    }
+
+    #[test]
+    fn parse_get_stale_and_unchanged() {
+        let operation = Get {
+            lease_ttl: Some(30),
+            ..Get::new("foo")
+        };
+        let result = parse_get(&operation, wire(b"VA 3 c7 X Z", Some(b"old"))).unwrap();
+        assert_eq!(result.status, GetStatus::Hit);
+        assert!(result.is_stale());
+        assert_eq!(result.value.as_deref(), Some(&b"old"[..]));
+
+        let operation = Get {
+            unless_cas: Some(42),
+            ..Get::new("foo")
+        };
+        let result = parse_get(&operation, wire(b"HD c42", None)).unwrap();
+        assert_eq!(result.status, GetStatus::Unchanged);
+        assert_eq!(result.value, None);
+    }
+
+    #[test]
+    fn parse_mutation_statuses() {
+        let set = Set::new("foo", "bar");
+        assert_eq!(
+            parse_set(&set, wire(b"HD", None)).unwrap().status,
+            MutationStatus::Stored
+        );
+        assert_eq!(
+            parse_set(&set, wire(b"EX", None)).unwrap().status,
+            MutationStatus::CasMismatch
+        );
+        assert_eq!(
+            parse_set(&set, wire(b"NS", None)).unwrap().status,
+            MutationStatus::NotFound
+        );
+        let add = Set {
+            mode: SetMode::Add,
+            ..Set::new("foo", "bar")
+        };
+        assert_eq!(
+            parse_set(&add, wire(b"NS", None)).unwrap().status,
+            MutationStatus::AlreadyExists
+        );
+        assert_eq!(
+            parse_delete(&Delete::new("foo"), wire(b"NF", None)).unwrap().status,
+            MutationStatus::NotFound
+        );
+    }
+
+    #[test]
+    fn parse_arithmetic_value() {
+        let operation = Arithmetic::new("counter");
+        let result = parse_arithmetic(&operation, wire(b"VA 2 c9 t60", Some(b"42"))).unwrap();
+        assert!(result.stored());
+        assert_eq!(result.value, Some(42));
+        assert_eq!(result.item.cas, Some(9));
+        assert_eq!(result.item.ttl, Some(60));
+
+        let result = parse_arithmetic(&operation, wire(b"NF", None)).unwrap();
+        assert_eq!(result.status, MutationStatus::NotFound);
+        assert_eq!(result.value, None);
+    }
+}

--- a/src/exp/core.rs
+++ b/src/exp/core.rs
@@ -17,6 +17,76 @@ use super::result::{
     ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, ValueState,
 };
 
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for super::Get {}
+    impl Sealed for super::Set {}
+    impl Sealed for super::Delete {}
+    impl Sealed for super::Arithmetic {}
+}
+
+/// An executable semantic-layer operation, implemented by [`Get`], [`Set`],
+/// [`Delete`] and [`Arithmetic`]. Sealed: not implementable outside this
+/// crate.
+pub trait Operation: sealed::Sealed {
+    /// The typed result this operation produces.
+    type Output;
+
+    #[doc(hidden)]
+    fn prepare(&self) -> Result<MetaCommand, MemcacheError>;
+
+    #[doc(hidden)]
+    fn parse(&self, wire: MetaCommandResult) -> Result<Self::Output, MemcacheError>;
+}
+
+impl Operation for Get {
+    type Output = GetResult;
+
+    fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
+        prepare_get(self)
+    }
+
+    fn parse(&self, wire: MetaCommandResult) -> Result<GetResult, MemcacheError> {
+        parse_get(self, wire)
+    }
+}
+
+impl Operation for Set {
+    type Output = MutationResult;
+
+    fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
+        prepare_set(self)
+    }
+
+    fn parse(&self, wire: MetaCommandResult) -> Result<MutationResult, MemcacheError> {
+        parse_set(self, wire)
+    }
+}
+
+impl Operation for Delete {
+    type Output = MutationResult;
+
+    fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
+        prepare_delete(self)
+    }
+
+    fn parse(&self, wire: MetaCommandResult) -> Result<MutationResult, MemcacheError> {
+        parse_delete(self, wire)
+    }
+}
+
+impl Operation for Arithmetic {
+    type Output = ArithmeticResult;
+
+    fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
+        prepare_arithmetic(self)
+    }
+
+    fn parse(&self, wire: MetaCommandResult) -> Result<ArithmeticResult, MemcacheError> {
+        parse_arithmetic(self, wire)
+    }
+}
+
 fn invalid<T>(message: &'static str) -> Result<T, MemcacheError> {
     Err(ClientError::Error(Cow::Borrowed(message)).into())
 }

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -13,26 +13,28 @@ The module is layered bottom-up:
   No serialization and no semantic interpretation happens at this level.
 - Operations ([`Get`], [`Set`], [`Delete`], [`Arithmetic`]) and typed results
   ([`GetResult`], [`MutationResult`], [`ArithmeticResult`]): the semantic
-  layer, interpreting return codes and lease/stale flags. Values are raw
-  bytes.
+  layer, interpreting return codes and lease/stale flags. Each operation
+  implements [`Operation`] with a typed `Output`. Values are raw bytes.
 - [`MetaClient`] (blocking) and [`AsyncMetaClient`] (tokio, behind the
-  `tokio` feature): single-server clients running one operation at a time.
+  `tokio` feature): single-server clients whose verbs return lazy
+  [`Request`] builders, executed with `send()`.
 
-Transports are TCP only. Serialization, multi-server routing and pipelining
+Transports are TCP only. Serialization, multi-server routing and batching
 are not implemented yet.
 
 # Example
 
 ```no_run
-use memcache::exp::{Get, MetaClient, Set};
+use memcache::exp::MetaClient;
 
 let mut client = MetaClient::connect("127.0.0.1:11211").unwrap();
-client.set(&Set::new("foo", "bar")).unwrap();
-let result = client.get(&Get::new("foo")).unwrap();
+client.set("foo", "bar").send().unwrap();
+let result = client.get("foo").send().unwrap();
 assert_eq!(result.value.as_deref(), Some(&b"bar"[..]));
 
-// Fields not covered by `new` are set with struct update syntax:
-client.set(&Set { ttl: Some(60), ..Set::new("foo", "bar") }).unwrap();
+// Options are chained before send():
+client.set("foo", "bar").ttl(60).add().send().unwrap();
+let counter = client.increment("hits").delta(2).initial(0, 60).send().unwrap();
 ```
 
 The wire layer remains available for anything the clients do not cover:
@@ -56,6 +58,7 @@ mod core;
 mod meta_api;
 mod meta_command;
 mod operation;
+mod request;
 mod result;
 
 #[cfg(feature = "tokio")]
@@ -69,6 +72,7 @@ pub use async_client::AsyncMetaClient;
 pub use async_connection::AsyncMetaConnection;
 pub use client::MetaClient;
 pub use connection::MetaConnection;
+pub use core::Operation;
 pub use meta_api::{
     ArithmeticMode, ArithmeticOptions, DeleteOptions, GetOptions, MetaCommandResult, SetMode, SetOptions,
     build_arithmetic, build_debug, build_delete, build_get, build_noop, build_set, parse_debug_result,
@@ -76,6 +80,7 @@ pub use meta_api::{
 };
 pub use meta_command::{MAX_KEY_LENGTH, MetaCommand, MetaOp, MetaResponse, ReturnCode};
 pub use operation::{Arithmetic, Delete, Get, Meta, Set};
+pub use request::Request;
 pub use result::{
     ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, ValueState,
 };

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -4,20 +4,38 @@ Experimental client built on the memcached
 
 Everything in this module is experimental and may change without notice.
 
-For now only the wire layer is implemented, split in two:
+The module is layered bottom-up:
 
 - [`MetaCommand`] / [`MetaResponse`]: framing — request assembly and response
   header parsing, including automatic base64 encoding of binary keys.
 - `build_*` / `parse_*` and the `*Options` structs: a typed 1:1 mapping of the
   protocol where every option field corresponds to exactly one protocol flag.
   No serialization and no semantic interpretation happens at this level.
+- Operations ([`Get`], [`Set`], [`Delete`], [`Arithmetic`]) and typed results
+  ([`GetResult`], [`MutationResult`], [`ArithmeticResult`]): the semantic
+  layer, interpreting return codes and lease/stale flags. Values are raw
+  bytes.
+- [`MetaClient`] (blocking) and [`AsyncMetaClient`] (tokio, behind the
+  `tokio` feature): single-server clients running one operation at a time.
 
-Transports are TCP only: [`MetaConnection`] (blocking) and
-[`AsyncMetaConnection`] (tokio, behind the `tokio` feature). A high-level
-client with serialization, typed results and pipelining will be layered on
-top later.
+Transports are TCP only. Serialization, multi-server routing and pipelining
+are not implemented yet.
 
 # Example
+
+```no_run
+use memcache::exp::{Get, MetaClient, Set};
+
+let mut client = MetaClient::connect("127.0.0.1:11211").unwrap();
+client.set(&Set::new("foo", "bar")).unwrap();
+let result = client.get(&Get::new("foo")).unwrap();
+assert_eq!(result.value.as_deref(), Some(&b"bar"[..]));
+
+// Fields not covered by `new` are set with struct update syntax:
+client.set(&Set { ttl: Some(60), ..Set::new("foo", "bar") }).unwrap();
+```
+
+The wire layer remains available for anything the clients do not cover:
 
 ```no_run
 use memcache::exp::{build_get, parse_meta_result, GetOptions, MetaConnection};
@@ -32,15 +50,24 @@ if result.ok() {
 ```
 */
 
+mod client;
 mod connection;
+mod core;
 mod meta_api;
 mod meta_command;
+mod operation;
+mod result;
 
+#[cfg(feature = "tokio")]
+mod async_client;
 #[cfg(feature = "tokio")]
 mod async_connection;
 
 #[cfg(feature = "tokio")]
+pub use async_client::AsyncMetaClient;
+#[cfg(feature = "tokio")]
 pub use async_connection::AsyncMetaConnection;
+pub use client::MetaClient;
 pub use connection::MetaConnection;
 pub use meta_api::{
     ArithmeticMode, ArithmeticOptions, DeleteOptions, GetOptions, MetaCommandResult, SetMode, SetOptions,
@@ -48,3 +75,7 @@ pub use meta_api::{
     parse_meta_result,
 };
 pub use meta_command::{MAX_KEY_LENGTH, MetaCommand, MetaOp, MetaResponse, ReturnCode};
+pub use operation::{Arithmetic, Delete, Get, Meta, Set};
+pub use result::{
+    ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, ValueState,
+};

--- a/src/exp/operation.rs
+++ b/src/exp/operation.rs
@@ -1,0 +1,173 @@
+//! Operation descriptions for the semantic layer.
+//!
+//! An operation captures *what* the caller wants (key, value, conditions,
+//! requested metadata) independently of the wire encoding. The core layer
+//! turns operations into [`MetaCommand`](super::MetaCommand)s and pairs them
+//! with their responses. Construct with `new` and adjust fields with struct
+//! update syntax: `Get { touch: Some(60), ..Get::new("foo") }`.
+
+use super::meta_api::{ArithmeticMode, SetMode};
+
+/// Which item metadata a [`Get`] should fetch into
+/// [`ItemMeta`](super::ItemMeta).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Meta {
+    pub cas: bool,
+    pub ttl: bool,
+    pub size: bool,
+    pub last_access: bool,
+    pub hit_before: bool,
+}
+
+impl Meta {
+    pub const NONE: Meta = Meta {
+        cas: false,
+        ttl: false,
+        size: false,
+        last_access: false,
+        hit_before: false,
+    };
+    pub const ALL: Meta = Meta {
+        cas: true,
+        ttl: true,
+        size: true,
+        last_access: true,
+        hit_before: true,
+    };
+}
+
+/// A read operation (`mg`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Get {
+    pub key: Vec<u8>,
+    /// Metadata to fetch alongside the value.
+    pub meta: Meta,
+    /// Update the item TTL while reading.
+    pub touch: Option<u32>,
+    /// Don't bump the item in the LRU.
+    pub no_lru_bump: bool,
+    /// Suppress the value when the item CAS still matches; the result status
+    /// becomes [`Unchanged`](super::GetStatus::Unchanged). Requires `value`.
+    pub unless_cas: Option<u64>,
+    /// Whether to read the value at all; `false` fetches metadata only.
+    pub value: bool,
+    /// Vivify a missing key with this TTL and request a lease; a miss then
+    /// reports [`LeaseState::Granted`](super::LeaseState::Granted) to exactly
+    /// one client. Must be >= 1.
+    pub lease_ttl: Option<u32>,
+    /// Also win the lease when the remaining TTL drops below this, to
+    /// refresh the value before it expires. Requires `lease_ttl`; must
+    /// be >= 1.
+    pub refresh_before: Option<u32>,
+}
+
+impl Get {
+    pub fn new(key: impl Into<Vec<u8>>) -> Get {
+        Get {
+            key: key.into(),
+            meta: Meta::NONE,
+            touch: None,
+            no_lru_bump: false,
+            unless_cas: None,
+            value: true,
+            lease_ttl: None,
+            refresh_before: None,
+        }
+    }
+}
+
+/// A store operation (`ms`). The value is raw bytes; serialization belongs
+/// to a higher layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Set {
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+    pub ttl: Option<u32>,
+    pub mode: SetMode,
+    /// Store only when the item CAS matches.
+    pub compare_cas: Option<u64>,
+    /// Replace the item CAS with this value instead of a server-chosen one.
+    pub version: Option<u64>,
+    /// Return the new item CAS in the result.
+    pub return_cas: bool,
+    /// For append/prepend, vivify a missing item with this TTL. Must be >= 1.
+    pub vivify_ttl: Option<u32>,
+}
+
+impl Set {
+    pub fn new(key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Set {
+        Set {
+            key: key.into(),
+            value: value.into(),
+            ttl: None,
+            mode: SetMode::Set,
+            compare_cas: None,
+            version: None,
+            return_cas: false,
+            vivify_ttl: None,
+        }
+    }
+}
+
+/// A delete operation (`md`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Delete {
+    pub key: Vec<u8>,
+    /// Delete only when the item CAS matches.
+    pub compare_cas: Option<u64>,
+    /// Mark the item stale instead of removing it; readers then see the old
+    /// value flagged stale until someone refreshes it.
+    pub invalidate: bool,
+    /// For invalidate, how long the stale item stays readable.
+    pub stale_for: Option<u32>,
+}
+
+impl Delete {
+    pub fn new(key: impl Into<Vec<u8>>) -> Delete {
+        Delete {
+            key: key.into(),
+            compare_cas: None,
+            invalidate: false,
+            stale_for: None,
+        }
+    }
+}
+
+/// A counter operation (`ma`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Arithmetic {
+    pub key: Vec<u8>,
+    pub delta: u64,
+    pub mode: ArithmeticMode,
+    /// Initial value when vivifying a missing item; requires `initial_ttl`.
+    pub initial: Option<u64>,
+    /// TTL for the vivified item; requires `initial`. Must be >= 1.
+    pub initial_ttl: Option<u32>,
+    /// Update the item TTL while applying the delta.
+    pub ttl: Option<u32>,
+    /// Apply only when the item CAS matches.
+    pub compare_cas: Option<u64>,
+    /// Replace the item CAS with this value instead of a server-chosen one.
+    pub version: Option<u64>,
+    /// Return the new item CAS in the result.
+    pub return_cas: bool,
+    /// Return the remaining TTL in the result.
+    pub return_ttl: bool,
+}
+
+impl Arithmetic {
+    pub fn new(key: impl Into<Vec<u8>>) -> Arithmetic {
+        Arithmetic {
+            key: key.into(),
+            delta: 1,
+            mode: ArithmeticMode::Increment,
+            initial: None,
+            initial_ttl: None,
+            ttl: None,
+            compare_cas: None,
+            version: None,
+            return_cas: false,
+            return_ttl: false,
+        }
+    }
+}

--- a/src/exp/operation.rs
+++ b/src/exp/operation.rs
@@ -3,8 +3,9 @@
 //! An operation captures *what* the caller wants (key, value, conditions,
 //! requested metadata) independently of the wire encoding. The core layer
 //! turns operations into [`MetaCommand`](super::MetaCommand)s and pairs them
-//! with their responses. Construct with `new` and adjust fields with struct
-//! update syntax: `Get { touch: Some(60), ..Get::new("foo") }`.
+//! with their responses. Construct with `new` and chain builder methods:
+//! `Get::new("foo").touch(60).lease_ttl(30)`. The fields stay public for
+//! struct update syntax and pattern matching.
 
 use super::meta_api::{ArithmeticMode, SetMode};
 
@@ -34,6 +35,36 @@ impl Meta {
         last_access: true,
         hit_before: true,
     };
+
+    #[must_use]
+    pub fn cas(mut self) -> Meta {
+        self.cas = true;
+        self
+    }
+
+    #[must_use]
+    pub fn ttl(mut self) -> Meta {
+        self.ttl = true;
+        self
+    }
+
+    #[must_use]
+    pub fn size(mut self) -> Meta {
+        self.size = true;
+        self
+    }
+
+    #[must_use]
+    pub fn last_access(mut self) -> Meta {
+        self.last_access = true;
+        self
+    }
+
+    #[must_use]
+    pub fn hit_before(mut self) -> Meta {
+        self.hit_before = true;
+        self
+    }
 }
 
 /// A read operation (`mg`).
@@ -74,6 +105,55 @@ impl Get {
             refresh_before: None,
         }
     }
+
+    /// Fetch this metadata alongside the value.
+    #[must_use]
+    pub fn meta(mut self, meta: Meta) -> Get {
+        self.meta = meta;
+        self
+    }
+
+    /// Update the item TTL while reading.
+    #[must_use]
+    pub fn touch(mut self, ttl: u32) -> Get {
+        self.touch = Some(ttl);
+        self
+    }
+
+    /// Don't bump the item in the LRU.
+    #[must_use]
+    pub fn no_lru_bump(mut self) -> Get {
+        self.no_lru_bump = true;
+        self
+    }
+
+    /// Suppress the value when the item CAS still matches.
+    #[must_use]
+    pub fn unless_cas(mut self, cas: u64) -> Get {
+        self.unless_cas = Some(cas);
+        self
+    }
+
+    /// Fetch metadata only, without the value.
+    #[must_use]
+    pub fn without_value(mut self) -> Get {
+        self.value = false;
+        self
+    }
+
+    /// Vivify a missing key with this TTL and request a lease.
+    #[must_use]
+    pub fn lease_ttl(mut self, ttl: u32) -> Get {
+        self.lease_ttl = Some(ttl);
+        self
+    }
+
+    /// Also win the lease when the remaining TTL drops below this.
+    #[must_use]
+    pub fn refresh_before(mut self, ttl: u32) -> Get {
+        self.refresh_before = Some(ttl);
+        self
+    }
 }
 
 /// A store operation (`ms`). The value is raw bytes; serialization belongs
@@ -107,6 +187,70 @@ impl Set {
             vivify_ttl: None,
         }
     }
+
+    #[must_use]
+    pub fn ttl(mut self, ttl: u32) -> Set {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    #[must_use]
+    pub fn mode(mut self, mode: SetMode) -> Set {
+        self.mode = mode;
+        self
+    }
+
+    /// Store only when the item does not exist.
+    #[must_use]
+    pub fn add(self) -> Set {
+        self.mode(SetMode::Add)
+    }
+
+    /// Store only when the item exists.
+    #[must_use]
+    pub fn replace(self) -> Set {
+        self.mode(SetMode::Replace)
+    }
+
+    /// Append raw bytes to the stored value.
+    #[must_use]
+    pub fn append(self) -> Set {
+        self.mode(SetMode::Append)
+    }
+
+    /// Prepend raw bytes to the stored value.
+    #[must_use]
+    pub fn prepend(self) -> Set {
+        self.mode(SetMode::Prepend)
+    }
+
+    /// Store only when the item CAS matches.
+    #[must_use]
+    pub fn compare_cas(mut self, cas: u64) -> Set {
+        self.compare_cas = Some(cas);
+        self
+    }
+
+    /// Replace the item CAS with this value.
+    #[must_use]
+    pub fn version(mut self, version: u64) -> Set {
+        self.version = Some(version);
+        self
+    }
+
+    /// Return the new item CAS in the result.
+    #[must_use]
+    pub fn return_cas(mut self) -> Set {
+        self.return_cas = true;
+        self
+    }
+
+    /// For append/prepend, vivify a missing item with this TTL.
+    #[must_use]
+    pub fn vivify_ttl(mut self, ttl: u32) -> Set {
+        self.vivify_ttl = Some(ttl);
+        self
+    }
 }
 
 /// A delete operation (`md`).
@@ -130,6 +274,27 @@ impl Delete {
             invalidate: false,
             stale_for: None,
         }
+    }
+
+    /// Delete only when the item CAS matches.
+    #[must_use]
+    pub fn compare_cas(mut self, cas: u64) -> Delete {
+        self.compare_cas = Some(cas);
+        self
+    }
+
+    /// Mark the item stale instead of removing it.
+    #[must_use]
+    pub fn invalidate(mut self) -> Delete {
+        self.invalidate = true;
+        self
+    }
+
+    /// For invalidate, how long the stale item stays readable.
+    #[must_use]
+    pub fn stale_for(mut self, ttl: u32) -> Delete {
+        self.stale_for = Some(ttl);
+        self
     }
 }
 
@@ -169,5 +334,99 @@ impl Arithmetic {
             return_cas: false,
             return_ttl: false,
         }
+    }
+
+    #[must_use]
+    pub fn delta(mut self, delta: u64) -> Arithmetic {
+        self.delta = delta;
+        self
+    }
+
+    /// Decrement instead of increment.
+    #[must_use]
+    pub fn decrement(mut self) -> Arithmetic {
+        self.mode = ArithmeticMode::Decrement;
+        self
+    }
+
+    /// Vivify a missing item with this value and TTL. The protocol requires
+    /// the pair, so they are set together.
+    #[must_use]
+    pub fn initial(mut self, value: u64, ttl: u32) -> Arithmetic {
+        self.initial = Some(value);
+        self.initial_ttl = Some(ttl);
+        self
+    }
+
+    /// Update the item TTL while applying the delta.
+    #[must_use]
+    pub fn ttl(mut self, ttl: u32) -> Arithmetic {
+        self.ttl = Some(ttl);
+        self
+    }
+
+    /// Apply only when the item CAS matches.
+    #[must_use]
+    pub fn compare_cas(mut self, cas: u64) -> Arithmetic {
+        self.compare_cas = Some(cas);
+        self
+    }
+
+    /// Replace the item CAS with this value.
+    #[must_use]
+    pub fn version(mut self, version: u64) -> Arithmetic {
+        self.version = Some(version);
+        self
+    }
+
+    /// Return the new item CAS in the result.
+    #[must_use]
+    pub fn return_cas(mut self) -> Arithmetic {
+        self.return_cas = true;
+        self
+    }
+
+    /// Return the remaining TTL in the result.
+    #[must_use]
+    pub fn return_ttl(mut self) -> Arithmetic {
+        self.return_ttl = true;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builders_set_fields() {
+        let get = Get::new("foo")
+            .meta(Meta::NONE.cas().ttl())
+            .touch(60)
+            .no_lru_bump()
+            .lease_ttl(30)
+            .refresh_before(10);
+        assert!(get.meta.cas && get.meta.ttl && !get.meta.size);
+        assert_eq!(get.touch, Some(60));
+        assert!(get.no_lru_bump);
+        assert_eq!(get.lease_ttl, Some(30));
+        assert_eq!(get.refresh_before, Some(10));
+        assert!(!Get::new("foo").without_value().value);
+
+        let set = Set::new("foo", "bar").ttl(60).add().compare_cas(7).return_cas();
+        assert_eq!(set.ttl, Some(60));
+        assert_eq!(set.mode, SetMode::Add);
+        assert_eq!(set.compare_cas, Some(7));
+        assert!(set.return_cas);
+
+        let delete = Delete::new("foo").invalidate().stale_for(30);
+        assert!(delete.invalidate);
+        assert_eq!(delete.stale_for, Some(30));
+
+        let arithmetic = Arithmetic::new("counter").delta(2).decrement().initial(0, 60);
+        assert_eq!(arithmetic.delta, 2);
+        assert_eq!(arithmetic.mode, ArithmeticMode::Decrement);
+        assert_eq!(arithmetic.initial, Some(0));
+        assert_eq!(arithmetic.initial_ttl, Some(60));
     }
 }

--- a/src/exp/request.rs
+++ b/src/exp/request.rs
@@ -1,0 +1,197 @@
+//! Lazy request builders returned by the client verbs.
+//!
+//! `client.get("foo")` and friends return a [`Request`] holding the client
+//! and an operation under construction. Option methods forward to the
+//! operation's builders; nothing touches the network until
+//! [`send`](Request::send). `Request` is generic over the client, so the
+//! option surface is written once and shared by the blocking and tokio
+//! clients — only `send` is implemented per client.
+
+use super::meta_api::SetMode;
+use super::operation::{Arithmetic, Delete, Get, Meta, Set};
+
+/// An operation bound to a client, awaiting [`send`](Request::send).
+#[must_use = "a request does nothing until you call .send()"]
+pub struct Request<'a, C, O> {
+    pub(crate) client: &'a mut C,
+    pub(crate) operation: O,
+}
+
+impl<'a, C, O> Request<'a, C, O> {
+    pub(crate) fn new(client: &'a mut C, operation: O) -> Request<'a, C, O> {
+        Request { client, operation }
+    }
+
+    /// Detach the operation as a standalone value, dropping the client
+    /// binding. Useful to build operations for a future batch API.
+    pub fn into_operation(self) -> O {
+        self.operation
+    }
+}
+
+impl<'a, C> Request<'a, C, Get> {
+    /// Fetch this metadata alongside the value.
+    pub fn meta(mut self, meta: Meta) -> Self {
+        self.operation = self.operation.meta(meta);
+        self
+    }
+
+    /// Update the item TTL while reading.
+    pub fn touch(mut self, ttl: u32) -> Self {
+        self.operation = self.operation.touch(ttl);
+        self
+    }
+
+    /// Don't bump the item in the LRU.
+    pub fn no_lru_bump(mut self) -> Self {
+        self.operation = self.operation.no_lru_bump();
+        self
+    }
+
+    /// Suppress the value when the item CAS still matches.
+    pub fn unless_cas(mut self, cas: u64) -> Self {
+        self.operation = self.operation.unless_cas(cas);
+        self
+    }
+
+    /// Fetch metadata only, without the value.
+    pub fn without_value(mut self) -> Self {
+        self.operation = self.operation.without_value();
+        self
+    }
+
+    /// Vivify a missing key with this TTL and request a lease.
+    pub fn lease_ttl(mut self, ttl: u32) -> Self {
+        self.operation = self.operation.lease_ttl(ttl);
+        self
+    }
+
+    /// Also win the lease when the remaining TTL drops below this.
+    pub fn refresh_before(mut self, ttl: u32) -> Self {
+        self.operation = self.operation.refresh_before(ttl);
+        self
+    }
+}
+
+impl<'a, C> Request<'a, C, Set> {
+    pub fn ttl(mut self, ttl: u32) -> Self {
+        self.operation = self.operation.ttl(ttl);
+        self
+    }
+
+    pub fn mode(mut self, mode: SetMode) -> Self {
+        self.operation = self.operation.mode(mode);
+        self
+    }
+
+    /// Store only when the item does not exist.
+    pub fn add(mut self) -> Self {
+        self.operation = self.operation.add();
+        self
+    }
+
+    /// Store only when the item exists.
+    pub fn replace(mut self) -> Self {
+        self.operation = self.operation.replace();
+        self
+    }
+
+    /// Append raw bytes to the stored value.
+    pub fn append(mut self) -> Self {
+        self.operation = self.operation.append();
+        self
+    }
+
+    /// Prepend raw bytes to the stored value.
+    pub fn prepend(mut self) -> Self {
+        self.operation = self.operation.prepend();
+        self
+    }
+
+    /// Store only when the item CAS matches.
+    pub fn compare_cas(mut self, cas: u64) -> Self {
+        self.operation = self.operation.compare_cas(cas);
+        self
+    }
+
+    /// Replace the item CAS with this value.
+    pub fn version(mut self, version: u64) -> Self {
+        self.operation = self.operation.version(version);
+        self
+    }
+
+    /// Return the new item CAS in the result.
+    pub fn return_cas(mut self) -> Self {
+        self.operation = self.operation.return_cas();
+        self
+    }
+
+    /// For append/prepend, vivify a missing item with this TTL.
+    pub fn vivify_ttl(mut self, ttl: u32) -> Self {
+        self.operation = self.operation.vivify_ttl(ttl);
+        self
+    }
+}
+
+impl<'a, C> Request<'a, C, Delete> {
+    /// Delete only when the item CAS matches.
+    pub fn compare_cas(mut self, cas: u64) -> Self {
+        self.operation = self.operation.compare_cas(cas);
+        self
+    }
+
+    /// Mark the item stale instead of removing it.
+    pub fn invalidate(mut self) -> Self {
+        self.operation = self.operation.invalidate();
+        self
+    }
+
+    /// For invalidate, how long the stale item stays readable.
+    pub fn stale_for(mut self, ttl: u32) -> Self {
+        self.operation = self.operation.stale_for(ttl);
+        self
+    }
+}
+
+impl<'a, C> Request<'a, C, Arithmetic> {
+    pub fn delta(mut self, delta: u64) -> Self {
+        self.operation = self.operation.delta(delta);
+        self
+    }
+
+    /// Vivify a missing item with this value and TTL.
+    pub fn initial(mut self, value: u64, ttl: u32) -> Self {
+        self.operation = self.operation.initial(value, ttl);
+        self
+    }
+
+    /// Update the item TTL while applying the delta.
+    pub fn ttl(mut self, ttl: u32) -> Self {
+        self.operation = self.operation.ttl(ttl);
+        self
+    }
+
+    /// Apply only when the item CAS matches.
+    pub fn compare_cas(mut self, cas: u64) -> Self {
+        self.operation = self.operation.compare_cas(cas);
+        self
+    }
+
+    /// Replace the item CAS with this value.
+    pub fn version(mut self, version: u64) -> Self {
+        self.operation = self.operation.version(version);
+        self
+    }
+
+    /// Return the new item CAS in the result.
+    pub fn return_cas(mut self) -> Self {
+        self.operation = self.operation.return_cas();
+        self
+    }
+
+    /// Return the remaining TTL in the result.
+    pub fn return_ttl(mut self) -> Self {
+        self.operation = self.operation.return_ttl();
+        self
+    }
+}

--- a/src/exp/result.rs
+++ b/src/exp/result.rs
@@ -1,0 +1,130 @@
+//! Typed results for the semantic layer.
+//!
+//! Results describe protocol-level outcomes (miss, CAS mismatch, lease
+//! state); transport and parse failures surface as
+//! [`MemcacheError`](crate::MemcacheError) instead. Batch-only outcomes
+//! (failed/ambiguous operations inside a pipeline) will be added together
+//! with the pipeline executor.
+
+/// Outcome of a [`Get`](super::Get) operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GetStatus {
+    /// The item was found (the value is present when it was requested).
+    Hit,
+    /// The item was not found.
+    Miss,
+    /// The item is a placeholder another client is currently filling.
+    Pending,
+    /// `unless_cas` matched, so the server suppressed the value.
+    Unchanged,
+}
+
+/// Outcome of a mutation ([`Set`](super::Set) / [`Delete`](super::Delete) /
+/// [`Arithmetic`](super::Arithmetic)).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MutationStatus {
+    /// The mutation was applied.
+    Stored,
+    /// The item does not exist.
+    NotFound,
+    /// Add mode: the item already exists.
+    AlreadyExists,
+    /// `compare_cas` did not match the item.
+    CasMismatch,
+}
+
+/// Freshness of a returned value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueState {
+    Fresh,
+    /// The item was invalidated and awaits a refresh.
+    Stale,
+    Missing,
+}
+
+/// Lease outcome of a [`Get`](super::Get) with `lease_ttl`/`refresh_before`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeaseState {
+    /// No lease was requested or granted.
+    None,
+    /// This client won the lease and should recompute the value.
+    Granted,
+    /// Another client holds the lease.
+    Busy,
+}
+
+/// Item metadata requested via [`Meta`](super::Meta); a field is `None` when
+/// it was not requested or the server did not send it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ItemMeta {
+    pub cas: Option<u64>,
+    /// Remaining TTL in seconds; `-1` means unlimited.
+    pub ttl: Option<i64>,
+    pub size: Option<u64>,
+    pub last_access: Option<u64>,
+    pub hit_before: Option<bool>,
+}
+
+/// Result of a [`Get`](super::Get) operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GetResult {
+    pub key: Vec<u8>,
+    pub status: GetStatus,
+    /// The raw value; present only on a [`Hit`](GetStatus::Hit) that
+    /// requested the value.
+    pub value: Option<Vec<u8>>,
+    pub item: ItemMeta,
+    pub value_state: ValueState,
+    pub lease_state: LeaseState,
+}
+
+impl GetResult {
+    pub fn hit(&self) -> bool {
+        self.status == GetStatus::Hit
+    }
+
+    pub fn is_stale(&self) -> bool {
+        self.value_state == ValueState::Stale
+    }
+
+    /// This client won the lease and should recompute the value.
+    pub fn won_lease(&self) -> bool {
+        self.lease_state == LeaseState::Granted
+    }
+
+    /// Another client already holds the lease.
+    pub fn lease_busy(&self) -> bool {
+        self.lease_state == LeaseState::Busy
+    }
+}
+
+/// Result of a [`Set`](super::Set) or [`Delete`](super::Delete) operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MutationResult {
+    pub key: Vec<u8>,
+    pub status: MutationStatus,
+    /// The new item CAS, when requested with `return_cas`.
+    pub cas: Option<u64>,
+}
+
+impl MutationResult {
+    pub fn stored(&self) -> bool {
+        self.status == MutationStatus::Stored
+    }
+}
+
+/// Result of an [`Arithmetic`](super::Arithmetic) operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArithmeticResult {
+    pub key: Vec<u8>,
+    pub status: MutationStatus,
+    /// The counter value after the operation, unless suppressed.
+    pub value: Option<u64>,
+    pub item: ItemMeta,
+}
+
+impl ArithmeticResult {
+    pub fn stored(&self) -> bool {
+        self.status == MutationStatus::Stored
+    }
+}


### PR DESCRIPTION
Build the semantic layer on top of the meta protocol wire layer from #165, so the `exp` module is now usable end-to-end against a single server.

- Operation types (`Get` / `Set` / `Delete` / `Arithmetic`) and typed results (`GetResult` / `MutationResult` / `ArithmeticResult`) with status enums for miss, CAS mismatch, lease and stale states
- A transport-independent core that turns operations into wire commands (with semantic validation) and pairs responses back into typed results, exposed through a sealed `Operation` trait with a typed `Output`
- `MetaClient` (blocking) and `AsyncMetaClient` (tokio feature) with a request-builder API: verbs return lazy builders, options are chained and `send()` executes, e.g. `client.set("foo", "bar").ttl(60).add().send()?`; the builder is generic over the client so both share one option surface
- Standalone operation values remain available via `run(operation)` / `into_operation()` as the basis for a future batch API

Serialization, multi-server routing and batching are left for later.