### PR TITLE
Add batch execution to exp module

### DIFF
--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -10,8 +10,9 @@ use super::async_connection::AsyncMetaConnection;
 use super::core::Operation;
 use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
 use super::meta_command::ReturnCode;
-use super::operation::{Arithmetic, Delete, Get, Set};
+use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
+use super::result::OpResult;
 
 /// The async counterpart of [`MetaClient`](super::MetaClient); the same
 /// request-builder surface over a tokio connection.
@@ -75,6 +76,35 @@ impl AsyncMetaClient {
         let command = operation.prepare()?;
         let wire = parse_meta_result(self.connection.execute(&command).await?)?;
         operation.parse(wire)
+    }
+
+    /// Run several operations in one round trip over this connection.
+    ///
+    /// All commands are validated before anything is written and executed
+    /// independently in order; one operation's semantic outcome (miss, CAS
+    /// mismatch, ...) shows up in its own result and does not stop the rest.
+    /// This is not a transaction.
+    pub async fn run_batch(
+        &mut self,
+        operations: impl IntoIterator<Item = Op>,
+    ) -> Result<Vec<OpResult>, MemcacheError> {
+        let operations: Vec<Op> = operations.into_iter().collect();
+        self.run_all(&operations).await
+    }
+
+    async fn run_all<O: Operation>(&mut self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
+        // Validate every operation before writing the first byte, so a bad
+        // option never leaves half a batch on the wire.
+        let mut commands = Vec::with_capacity(operations.len());
+        for operation in operations {
+            commands.push(operation.prepare()?);
+        }
+        let responses = self.connection.execute_batch(&commands).await?;
+        operations
+            .iter()
+            .zip(responses)
+            .map(|(operation, response)| operation.parse(parse_meta_result(response)?))
+            .collect()
     }
 
     /// Round-trip an `mn` no-op; useful as a connection health check.

--- a/src/exp/async_connection.rs
+++ b/src/exp/async_connection.rs
@@ -62,6 +62,23 @@ impl AsyncMetaConnection {
         self.receive().await
     }
 
+    /// Write all commands in one payload, then read one response per
+    /// command. Quiet-mode (`q`) commands would desynchronize the stream and
+    /// must not be used here.
+    pub async fn execute_batch(&mut self, commands: &[MetaCommand]) -> Result<Vec<MetaResponse>, MemcacheError> {
+        let mut payload = Vec::new();
+        for command in commands {
+            command.encode_into(&mut payload)?;
+        }
+        self.reader.write_all(&payload).await?;
+        self.reader.flush().await?;
+        let mut responses = Vec::with_capacity(commands.len());
+        for _ in commands {
+            responses.push(self.receive().await?);
+        }
+        Ok(responses)
+    }
+
     async fn read_line(&mut self) -> Result<Vec<u8>, MemcacheError> {
         let mut line = Vec::new();
         self.reader.read_until(b'\n', &mut line).await?;

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -9,8 +9,9 @@ use super::connection::MetaConnection;
 use super::core::Operation;
 use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
 use super::meta_command::ReturnCode;
-use super::operation::{Arithmetic, Delete, Get, Set};
+use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
+use super::result::OpResult;
 
 /// A blocking meta protocol client for a single server.
 ///
@@ -72,6 +73,41 @@ impl MetaClient {
         let command = operation.prepare()?;
         let wire = parse_meta_result(self.connection.execute(&command)?)?;
         operation.parse(wire)
+    }
+
+    /// Run several operations in one round trip over this connection.
+    ///
+    /// All commands are validated before anything is written and executed
+    /// independently in order; one operation's semantic outcome (miss, CAS
+    /// mismatch, ...) shows up in its own result and does not stop the rest.
+    /// This is not a transaction.
+    ///
+    /// ```no_run
+    /// # use memcache::exp::{Get, MetaClient, Set};
+    /// # let mut client = MetaClient::connect("127.0.0.1:11211").unwrap();
+    /// let results = client.run_batch(vec![
+    ///     Set::new("foo", "bar").ttl(60).into(),
+    ///     Get::new("baz").into(),
+    /// ]).unwrap();
+    /// ```
+    pub fn run_batch(&mut self, operations: impl IntoIterator<Item = Op>) -> Result<Vec<OpResult>, MemcacheError> {
+        let operations: Vec<Op> = operations.into_iter().collect();
+        self.run_all(&operations)
+    }
+
+    fn run_all<O: Operation>(&mut self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
+        // Validate every operation before writing the first byte, so a bad
+        // option never leaves half a batch on the wire.
+        let mut commands = Vec::with_capacity(operations.len());
+        for operation in operations {
+            commands.push(operation.prepare()?);
+        }
+        let responses = self.connection.execute_batch(&commands)?;
+        operations
+            .iter()
+            .zip(responses)
+            .map(|(operation, response)| operation.parse(parse_meta_result(response)?))
+            .collect()
     }
 
     /// Round-trip an `mn` no-op; useful as a connection health check.
@@ -171,6 +207,44 @@ mod tests {
         assert_eq!(requests[3], b"ma counter v D2\r\n".to_vec());
         assert_eq!(requests[4], b"md foo\r\n".to_vec());
         assert_eq!(requests[5], b"mn\r\n".to_vec());
+    }
+
+    #[test]
+    fn run_batch_mixed_operations() {
+        let (addr, server) = scripted_server(vec![b"HD\r\n", b"VA 1 f0\r\n1\r\n", b"NF\r\n"]);
+        let mut client = MetaClient::connect(addr).unwrap();
+
+        let results = client
+            .run_batch(vec![
+                Set::new("a", "1").ttl(60).into(),
+                Get::new("b").into(),
+                Delete::new("c").into(),
+            ])
+            .unwrap();
+        assert_eq!(results.len(), 3);
+        assert!(results[0].as_mutation().unwrap().stored());
+        assert_eq!(results[1].as_get().unwrap().value.as_deref(), Some(&b"1"[..]));
+        assert_eq!(results[2].as_mutation().unwrap().status, MutationStatus::NotFound);
+
+        // All three commands were written before the first response was read.
+        let requests = server.join().unwrap();
+        assert_eq!(requests[0], b"ms a 1 T60\r\n".to_vec());
+        assert_eq!(requests[1], b"mg b v f\r\n".to_vec());
+        assert_eq!(requests[2], b"md c\r\n".to_vec());
+    }
+
+    #[test]
+    fn run_batch_validates_before_writing() {
+        let (addr, server) = scripted_server(vec![b"MN\r\n"]);
+        let mut client = MetaClient::connect(addr).unwrap();
+
+        // The second operation is invalid; nothing must reach the server.
+        let error = client.run_batch(vec![Set::new("a", "1").into(), Delete::new("b").stale_for(30).into()]);
+        assert!(error.is_err());
+
+        client.noop().unwrap();
+        let requests = server.join().unwrap();
+        assert_eq!(requests, vec![b"mn\r\n".to_vec()]);
     }
 
     #[test]

--- a/src/exp/connection.rs
+++ b/src/exp/connection.rs
@@ -60,6 +60,22 @@ impl MetaConnection {
         self.receive()
     }
 
+    /// Write all commands in one payload, then read one response per
+    /// command. Quiet-mode (`q`) commands would desynchronize the stream and
+    /// must not be used here.
+    pub fn execute_batch(&mut self, commands: &[MetaCommand]) -> Result<Vec<MetaResponse>, MemcacheError> {
+        let mut payload = Vec::new();
+        for command in commands {
+            command.encode_into(&mut payload)?;
+        }
+        self.reader.get_mut().write_all(&payload)?;
+        let mut responses = Vec::with_capacity(commands.len());
+        for _ in commands {
+            responses.push(self.receive()?);
+        }
+        Ok(responses)
+    }
+
     fn read_line(&mut self) -> Result<Vec<u8>, MemcacheError> {
         let mut line = Vec::new();
         self.reader.read_until(b'\n', &mut line)?;

--- a/src/exp/core.rs
+++ b/src/exp/core.rs
@@ -12,9 +12,9 @@ use super::meta_api::{
     build_delete, build_get, build_set,
 };
 use super::meta_command::{MetaCommand, ReturnCode};
-use super::operation::{Arithmetic, Delete, Get, Set};
+use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::result::{
-    ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, ValueState,
+    ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, OpResult, ValueState,
 };
 
 mod sealed {
@@ -23,6 +23,7 @@ mod sealed {
     impl Sealed for super::Set {}
     impl Sealed for super::Delete {}
     impl Sealed for super::Arithmetic {}
+    impl Sealed for super::Op {}
 }
 
 /// An executable semantic-layer operation, implemented by [`Get`], [`Set`],
@@ -84,6 +85,28 @@ impl Operation for Arithmetic {
 
     fn parse(&self, wire: MetaCommandResult) -> Result<ArithmeticResult, MemcacheError> {
         parse_arithmetic(self, wire)
+    }
+}
+
+impl Operation for Op {
+    type Output = OpResult;
+
+    fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
+        match self {
+            Op::Get(operation) => operation.prepare(),
+            Op::Set(operation) => operation.prepare(),
+            Op::Delete(operation) => operation.prepare(),
+            Op::Arithmetic(operation) => operation.prepare(),
+        }
+    }
+
+    fn parse(&self, wire: MetaCommandResult) -> Result<OpResult, MemcacheError> {
+        match self {
+            Op::Get(operation) => operation.parse(wire).map(OpResult::Get),
+            Op::Set(operation) => operation.parse(wire).map(OpResult::Mutation),
+            Op::Delete(operation) => operation.parse(wire).map(OpResult::Mutation),
+            Op::Arithmetic(operation) => operation.parse(wire).map(OpResult::Arithmetic),
+        }
     }
 }
 

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -19,8 +19,13 @@ The module is layered bottom-up:
   `tokio` feature): single-server clients whose verbs return lazy
   [`Request`] builders, executed with `send()`.
 
-Transports are TCP only. Serialization, multi-server routing and batching
-are not implemented yet.
+Several operations can run in one round trip: `run_batch` takes
+heterogeneous [`Op`] values and returns [`OpResult`]s. Batched operations
+execute independently and in order on one connection — a batch is not a
+transaction.
+
+Transports are TCP only. Serialization and multi-server routing are not
+implemented yet.
 
 # Example
 
@@ -35,6 +40,12 @@ assert_eq!(result.value.as_deref(), Some(&b"bar"[..]));
 // Options are chained before send():
 client.set("foo", "bar").ttl(60).add().send().unwrap();
 let counter = client.increment("hits").delta(2).initial(0, 60).send().unwrap();
+
+// Several operations in one round trip:
+use memcache::exp::{Get, Set};
+let results = client
+    .run_batch(vec![Set::new("a", "1").ttl(60).into(), Get::new("b").into()])
+    .unwrap();
 ```
 
 The wire layer remains available for anything the clients do not cover:
@@ -79,8 +90,8 @@ pub use meta_api::{
     parse_meta_result,
 };
 pub use meta_command::{MAX_KEY_LENGTH, MetaCommand, MetaOp, MetaResponse, ReturnCode};
-pub use operation::{Arithmetic, Delete, Get, Meta, Set};
+pub use operation::{Arithmetic, Delete, Get, Meta, Op, Set};
 pub use request::Request;
 pub use result::{
-    ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, ValueState,
+    ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, OpResult, ValueState,
 };

--- a/src/exp/operation.rs
+++ b/src/exp/operation.rs
@@ -394,6 +394,40 @@ impl Arithmetic {
     }
 }
 
+/// Any operation, for heterogeneous batches: `client.run_batch([op.into(),
+/// ...])`. Running an `Op` yields an [`OpResult`](super::OpResult).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Op {
+    Get(Get),
+    Set(Set),
+    Delete(Delete),
+    Arithmetic(Arithmetic),
+}
+
+impl From<Get> for Op {
+    fn from(operation: Get) -> Op {
+        Op::Get(operation)
+    }
+}
+
+impl From<Set> for Op {
+    fn from(operation: Set) -> Op {
+        Op::Set(operation)
+    }
+}
+
+impl From<Delete> for Op {
+    fn from(operation: Delete) -> Op {
+        Op::Delete(operation)
+    }
+}
+
+impl From<Arithmetic> for Op {
+    fn from(operation: Arithmetic) -> Op {
+        Op::Arithmetic(operation)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/exp/result.rs
+++ b/src/exp/result.rs
@@ -128,3 +128,36 @@ impl ArithmeticResult {
         self.status == MutationStatus::Stored
     }
 }
+
+/// Result of an [`Op`](super::Op) in a batch, one variant per operation
+/// kind ([`Set`](super::Set) and [`Delete`](super::Delete) both yield
+/// `Mutation`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpResult {
+    Get(GetResult),
+    Mutation(MutationResult),
+    Arithmetic(ArithmeticResult),
+}
+
+impl OpResult {
+    pub fn as_get(&self) -> Option<&GetResult> {
+        match self {
+            OpResult::Get(result) => Some(result),
+            _ => None,
+        }
+    }
+
+    pub fn as_mutation(&self) -> Option<&MutationResult> {
+        match self {
+            OpResult::Mutation(result) => Some(result),
+            _ => None,
+        }
+    }
+
+    pub fn as_arithmetic(&self) -> Option<&ArithmeticResult> {
+        match self {
+            OpResult::Arithmetic(result) => Some(result),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
Run several operations in one round trip over a single connection, on top of the request builder API from #166.

- `execute_batch` on both connections: encode all commands into one payload, write once, then read one framed response per command
- `Op` / `OpResult` enums for heterogeneous batches, with `From` impls so operations convert via `.into()`; `Op` also implements `Operation`, so `run` accepts it too
- `run_batch` on both clients: validates every operation before writing the first byte, and reads all responses before parsing so a semantic parse error never desynchronizes the stream; operations execute independently in order (a batch is not a transaction)

Multi-server routing (splitting a batch across connections) is left for later.