### PR TITLE
Add typed value encoding to exp module

### DIFF
--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -13,6 +13,7 @@ use super::meta_command::ReturnCode;
 use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
 use super::result::OpResult;
+use super::value::ToValue;
 
 /// The async counterpart of [`MetaClient`](super::MetaClient); the same
 /// request-builder surface over a tokio connection.
@@ -46,8 +47,9 @@ impl AsyncMetaClient {
         Request::new(self, Get::new(key))
     }
 
-    /// Store a value under a key.
-    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Set> {
+    /// Store a value under a key; the value is encoded via
+    /// [`ToValue`](super::ToValue).
+    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl ToValue) -> Request<'_, AsyncMetaClient, Set> {
         Request::new(self, Set::new(key, value))
     }
 

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -12,6 +12,7 @@ use super::meta_command::ReturnCode;
 use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
 use super::result::OpResult;
+use super::value::ToValue;
 
 /// A blocking meta protocol client for a single server.
 ///
@@ -43,8 +44,9 @@ impl MetaClient {
         Request::new(self, Get::new(key))
     }
 
-    /// Store a value under a key.
-    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Set> {
+    /// Store a value under a key; the value is encoded via
+    /// [`ToValue`](super::ToValue).
+    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl ToValue) -> Request<'_, MetaClient, Set> {
         Request::new(self, Set::new(key, value))
     }
 
@@ -201,9 +203,9 @@ mod tests {
         client.noop().unwrap();
 
         let requests = server.join().unwrap();
-        assert_eq!(requests[0], b"ms foo 3\r\n".to_vec());
+        assert_eq!(requests[0], b"ms foo 3 F16\r\n".to_vec());
         assert_eq!(requests[1], b"mg foo v f\r\n".to_vec());
-        assert_eq!(requests[2], b"ms foo 3 ME\r\n".to_vec());
+        assert_eq!(requests[2], b"ms foo 3 ME F16\r\n".to_vec());
         assert_eq!(requests[3], b"ma counter v D2\r\n".to_vec());
         assert_eq!(requests[4], b"md foo\r\n".to_vec());
         assert_eq!(requests[5], b"mn\r\n".to_vec());
@@ -228,7 +230,7 @@ mod tests {
 
         // All three commands were written before the first response was read.
         let requests = server.join().unwrap();
-        assert_eq!(requests[0], b"ms a 1 T60\r\n".to_vec());
+        assert_eq!(requests[0], b"ms a 1 F16 T60\r\n".to_vec());
         assert_eq!(requests[1], b"mg b v f\r\n".to_vec());
         assert_eq!(requests[2], b"md c\r\n".to_vec());
     }
@@ -259,7 +261,7 @@ mod tests {
         assert_eq!(decremented.value, Some(1));
 
         let requests = server.join().unwrap();
-        assert_eq!(requests[0], b"ms foo 3 T60\r\n".to_vec());
+        assert_eq!(requests[0], b"ms foo 3 F16 T60\r\n".to_vec());
         assert_eq!(requests[1], b"ma counter MD v D1\r\n".to_vec());
     }
 }

--- a/src/exp/core.rs
+++ b/src/exp/core.rs
@@ -156,6 +156,8 @@ pub(crate) fn prepare_set(operation: &Set) -> Result<MetaCommand, MemcacheError>
         return invalid("vivify_ttl must be >= 1");
     }
     let options = SetOptions {
+        // An omitted F stores flags 0, so only non-zero flags go on the wire.
+        client_flags: (operation.client_flags != 0).then_some(operation.client_flags),
         ttl: operation.ttl,
         mode: operation.mode,
         compare_cas: operation.compare_cas,
@@ -223,6 +225,7 @@ pub(crate) fn parse_get(operation: &Get, wire: MetaCommandResult) -> Result<GetR
             key: operation.key.clone(),
             status: GetStatus::Miss,
             value: None,
+            client_flags: None,
             item: ItemMeta::default(),
             value_state: ValueState::Missing,
             lease_state: LeaseState::None,
@@ -274,6 +277,7 @@ pub(crate) fn parse_get(operation: &Get, wire: MetaCommandResult) -> Result<GetR
         key: operation.key.clone(),
         status,
         value,
+        client_flags: wire.client_flags,
         item,
         value_state,
         lease_state,
@@ -384,7 +388,11 @@ mod tests {
 
     #[test]
     fn prepare_set_wire_format() {
+        // A &str value carries FLAG_STR (16) from ToValue.
         let command = prepare_set(&Set::new("foo", "bar")).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ms foo 3 F16\r\nbar\r\n".to_vec());
+
+        let command = prepare_set(&Set::new("foo", b"bar")).unwrap();
         assert_eq!(command.encode().unwrap(), b"ms foo 3\r\nbar\r\n".to_vec());
 
         let operation = Set {
@@ -394,7 +402,15 @@ mod tests {
             ..Set::new("foo", "bar")
         };
         let command = prepare_set(&operation).unwrap();
-        assert_eq!(command.encode().unwrap(), b"ms foo 3 ME c T60\r\nbar\r\n".to_vec());
+        assert_eq!(command.encode().unwrap(), b"ms foo 3 ME c F16 T60\r\nbar\r\n".to_vec());
+
+        // Non-zero client flags from ToValue go on the wire as F.
+        let operation = Set {
+            client_flags: 5,
+            ..Set::new("foo", "bar")
+        };
+        let command = prepare_set(&operation).unwrap();
+        assert_eq!(command.encode().unwrap(), b"ms foo 3 F5\r\nbar\r\n".to_vec());
     }
 
     #[test]

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -41,6 +41,10 @@ assert_eq!(result.value.as_deref(), Some(&b"bar"[..]));
 client.set("foo", "bar").ttl(60).add().send().unwrap();
 let counter = client.increment("hits").delta(2).initial(0, 60).send().unwrap();
 
+// Values are encoded via ToValue and decoded by the requested type:
+client.set("visits", 41u64).send().unwrap();
+let visits: Option<u64> = client.get("visits").send().unwrap().decode().unwrap();
+
 // Several operations in one round trip:
 use memcache::exp::{Get, Set};
 let results = client
@@ -71,6 +75,7 @@ mod meta_command;
 mod operation;
 mod request;
 mod result;
+mod value;
 
 #[cfg(feature = "tokio")]
 mod async_client;
@@ -95,3 +100,4 @@ pub use request::Request;
 pub use result::{
     ArithmeticResult, GetResult, GetStatus, ItemMeta, LeaseState, MutationResult, MutationStatus, OpResult, ValueState,
 };
+pub use value::{FLAG_BYTES, FLAG_INT, FLAG_STR, FromValue, ToValue};

--- a/src/exp/operation.rs
+++ b/src/exp/operation.rs
@@ -8,6 +8,7 @@
 //! struct update syntax and pattern matching.
 
 use super::meta_api::{ArithmeticMode, SetMode};
+use super::value::ToValue;
 
 /// Which item metadata a [`Get`] should fetch into
 /// [`ItemMeta`](super::ItemMeta).
@@ -156,12 +157,15 @@ impl Get {
     }
 }
 
-/// A store operation (`ms`). The value is raw bytes; serialization belongs
-/// to a higher layer.
+/// A store operation (`ms`). The value is encoded up front via
+/// [`ToValue`]; `value` holds the raw bytes and `client_flags` the flags
+/// stored with the item.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Set {
     pub key: Vec<u8>,
     pub value: Vec<u8>,
+    /// `F<flags>` — client flags stored with the item, from [`ToValue`].
+    pub client_flags: u32,
     pub ttl: Option<u32>,
     pub mode: SetMode,
     /// Store only when the item CAS matches.
@@ -175,10 +179,12 @@ pub struct Set {
 }
 
 impl Set {
-    pub fn new(key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) -> Set {
+    pub fn new(key: impl Into<Vec<u8>>, value: impl ToValue) -> Set {
+        let (value, client_flags) = value.to_value();
         Set {
             key: key.into(),
-            value: value.into(),
+            value,
+            client_flags,
             ttl: None,
             mode: SetMode::Set,
             compare_cas: None,

--- a/src/exp/result.rs
+++ b/src/exp/result.rs
@@ -6,6 +6,10 @@
 //! (failed/ambiguous operations inside a pipeline) will be added together
 //! with the pipeline executor.
 
+use crate::error::MemcacheError;
+
+use super::value::FromValue;
+
 /// Outcome of a [`Get`](super::Get) operation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GetStatus {
@@ -73,6 +77,9 @@ pub struct GetResult {
     /// The raw value; present only on a [`Hit`](GetStatus::Hit) that
     /// requested the value.
     pub value: Option<Vec<u8>>,
+    /// The client flags stored with the item, used by
+    /// [`decode`](Self::decode).
+    pub client_flags: Option<u32>,
     pub item: ItemMeta,
     pub value_state: ValueState,
     pub lease_state: LeaseState,
@@ -81,6 +88,19 @@ pub struct GetResult {
 impl GetResult {
     pub fn hit(&self) -> bool {
         self.status == GetStatus::Hit
+    }
+
+    /// Decode the value into the requested type via
+    /// [`FromValue`](super::FromValue); `Ok(None)` when there is no value.
+    ///
+    /// ```no_run
+    /// # use memcache::exp::MetaClient;
+    /// # let mut client = MetaClient::connect("127.0.0.1:11211").unwrap();
+    /// let count: Option<u64> = client.get("hits").send().unwrap().decode().unwrap();
+    /// ```
+    pub fn decode<V: FromValue>(self) -> Result<Option<V>, MemcacheError> {
+        let flags = self.client_flags.unwrap_or(0);
+        self.value.map(|value| V::from_value(value, flags)).transpose()
     }
 
     pub fn is_stale(&self) -> bool {

--- a/src/exp/value.rs
+++ b/src/exp/value.rs
@@ -1,0 +1,161 @@
+//! Value encoding for the semantic layer.
+//!
+//! [`ToValue`] turns a value into raw bytes plus the client flags stored
+//! with the item; [`FromValue`] decodes them back, driven by the type the
+//! caller requests. The built-in implementations store strings and bytes
+//! verbatim and numbers as their decimal ASCII form (which keeps them
+//! usable by `ma` arithmetic), tagged with the conventional flag for the
+//! type: [`FLAG_INT`] for integers, [`FLAG_STR`] for strings and
+//! [`FLAG_BYTES`] (zero) for everything else.
+//!
+//! Decoding is driven purely by the requested type; the built-in
+//! implementations ignore the stored flags, so anything a client wrote —
+//! flagged or not — decodes as long as the bytes parse. Flags will start
+//! participating in decoding once flag-bearing encodings (compression,
+//! JSON, ...) are supported; custom implementations can already use them.
+
+use std::str::FromStr;
+
+use crate::error::MemcacheError;
+
+/// Untyped raw bytes (the protocol default of zero).
+pub const FLAG_BYTES: u32 = 0;
+/// An integer stored as decimal ASCII.
+pub const FLAG_INT: u32 = 1 << 1;
+/// A UTF-8 string.
+pub const FLAG_STR: u32 = 1 << 4;
+
+/// Encode a value into `(bytes, client_flags)` for storage.
+pub trait ToValue {
+    fn to_value(&self) -> (Vec<u8>, u32);
+}
+
+/// Decode a stored `(bytes, client_flags)` back into a value.
+pub trait FromValue: Sized {
+    fn from_value(value: Vec<u8>, flags: u32) -> Result<Self, MemcacheError>;
+}
+
+impl ToValue for Vec<u8> {
+    fn to_value(&self) -> (Vec<u8>, u32) {
+        (self.clone(), FLAG_BYTES)
+    }
+}
+
+impl ToValue for &[u8] {
+    fn to_value(&self) -> (Vec<u8>, u32) {
+        (self.to_vec(), FLAG_BYTES)
+    }
+}
+
+impl<const N: usize> ToValue for &[u8; N] {
+    fn to_value(&self) -> (Vec<u8>, u32) {
+        (self.to_vec(), FLAG_BYTES)
+    }
+}
+
+impl ToValue for String {
+    fn to_value(&self) -> (Vec<u8>, u32) {
+        (self.as_bytes().to_vec(), FLAG_STR)
+    }
+}
+
+impl ToValue for &String {
+    fn to_value(&self) -> (Vec<u8>, u32) {
+        (self.as_bytes().to_vec(), FLAG_STR)
+    }
+}
+
+impl ToValue for &str {
+    fn to_value(&self) -> (Vec<u8>, u32) {
+        (self.as_bytes().to_vec(), FLAG_STR)
+    }
+}
+
+impl FromValue for Vec<u8> {
+    fn from_value(value: Vec<u8>, _flags: u32) -> Result<Self, MemcacheError> {
+        Ok(value)
+    }
+}
+
+impl FromValue for String {
+    fn from_value(value: Vec<u8>, _flags: u32) -> Result<Self, MemcacheError> {
+        Ok(String::from_utf8(value)?)
+    }
+}
+
+macro_rules! impl_value_for_integer {
+    ($ty:ident) => {
+        impl ToValue for $ty {
+            fn to_value(&self) -> (Vec<u8>, u32) {
+                (self.to_string().into_bytes(), FLAG_INT)
+            }
+        }
+
+        impl FromValue for $ty {
+            fn from_value(value: Vec<u8>, _flags: u32) -> Result<Self, MemcacheError> {
+                Ok(Self::from_str(std::str::from_utf8(&value)?)?)
+            }
+        }
+    };
+}
+
+impl_value_for_integer!(u8);
+impl_value_for_integer!(u16);
+impl_value_for_integer!(u32);
+impl_value_for_integer!(u64);
+impl_value_for_integer!(i8);
+impl_value_for_integer!(i16);
+impl_value_for_integer!(i32);
+impl_value_for_integer!(i64);
+
+// bool and floats have no conventional flag; they are stored as untyped
+// ASCII text.
+macro_rules! impl_value_for_text_scalar {
+    ($ty:ident) => {
+        impl ToValue for $ty {
+            fn to_value(&self) -> (Vec<u8>, u32) {
+                (self.to_string().into_bytes(), FLAG_BYTES)
+            }
+        }
+
+        impl FromValue for $ty {
+            fn from_value(value: Vec<u8>, _flags: u32) -> Result<Self, MemcacheError> {
+                Ok(Self::from_str(std::str::from_utf8(&value)?)?)
+            }
+        }
+    };
+}
+
+impl_value_for_text_scalar!(bool);
+impl_value_for_text_scalar!(f32);
+impl_value_for_text_scalar!(f64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_builtin_types() {
+        assert_eq!("bar".to_value(), (b"bar".to_vec(), FLAG_STR));
+        assert_eq!(String::from("bar").to_value(), (b"bar".to_vec(), FLAG_STR));
+        assert_eq!(b"bar".to_value(), (b"bar".to_vec(), FLAG_BYTES));
+        assert_eq!(42u64.to_value(), (b"42".to_vec(), FLAG_INT));
+        assert_eq!((-1i32).to_value(), (b"-1".to_vec(), FLAG_INT));
+        assert_eq!(true.to_value(), (b"true".to_vec(), FLAG_BYTES));
+        assert_eq!(1.5f64.to_value(), (b"1.5".to_vec(), FLAG_BYTES));
+    }
+
+    #[test]
+    fn decode_is_type_driven() {
+        assert_eq!(String::from_value(b"bar".to_vec(), FLAG_STR).unwrap(), "bar");
+        assert_eq!(u64::from_value(b"42".to_vec(), FLAG_INT).unwrap(), 42);
+        assert_eq!(f64::from_value(b"1.5".to_vec(), FLAG_BYTES).unwrap(), 1.5);
+        assert!(bool::from_value(b"true".to_vec(), FLAG_BYTES).unwrap());
+        assert!(u64::from_value(b"x".to_vec(), FLAG_INT).is_err());
+
+        // Flags are ignored: any value decodes as long as the bytes parse.
+        assert_eq!(String::from_value(b"42".to_vec(), FLAG_INT).unwrap(), "42");
+        assert_eq!(u64::from_value(b"42".to_vec(), FLAG_STR).unwrap(), 42);
+        assert_eq!(Vec::<u8>::from_value(b"x".to_vec(), 1).unwrap(), b"x".to_vec());
+    }
+}

--- a/tests/test_exp.rs
+++ b/tests/test_exp.rs
@@ -172,6 +172,26 @@ fn exp_lease() {
 }
 
 #[test]
+fn exp_typed_values() {
+    let mut client = MetaClient::connect(SERVER).unwrap();
+    let key = gen_random_key();
+
+    // Numbers are stored as decimal ASCII, so arithmetic works on them.
+    client.set(&*key, 41u64).send().unwrap();
+    assert_eq!(client.increment(&*key).send().unwrap().value, Some(42));
+    let count: Option<u64> = client.get(&*key).send().unwrap().decode().unwrap();
+    assert_eq!(count, Some(42));
+
+    client.set(&*key, String::from("text")).send().unwrap();
+    let text: Option<String> = client.get(&*key).send().unwrap().decode().unwrap();
+    assert_eq!(text.as_deref(), Some("text"));
+    assert!(client.get(&*key).send().unwrap().decode::<u64>().is_err());
+
+    let missing: Option<String> = client.get(&*gen_random_key()).send().unwrap().decode().unwrap();
+    assert_eq!(missing, None);
+}
+
+#[test]
 fn exp_debug() {
     let mut client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();


### PR DESCRIPTION
Store and read typed values through the exp clients instead of raw bytes only.

- `ToValue` / `FromValue` traits with built-in impls: strings and bytes are stored verbatim, integers/bool/floats as decimal ASCII (so counters stay usable by `ma` arithmetic)
- Writes tag values with the conventional client flags (`FLAG_INT`, `FLAG_STR`, 0 for bytes) for interoperability with clients that decode by flags; reads are driven purely by the requested type via `GetResult::decode::<T>()` and ignore flags for now — flags will start participating once flag-bearing encodings (compression, JSON) are added
- `Set` now encodes its value up front and carries `client_flags`; `GetResult` keeps the returned client flags instead of dropping them