### PR TITLE
Add multi-server routing to exp module

### DIFF
--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -1,22 +1,24 @@
-//! Tokio single-server client over the semantic layer.
+//! Tokio client over the semantic layer.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use tokio::net::ToSocketAddrs;
 
-use crate::error::{MemcacheError, ServerError};
+use crate::error::{ClientError, MemcacheError, ServerError};
 
 use super::async_connection::AsyncMetaConnection;
+use super::client::{default_hash_function, jump_hash};
 use super::core::Operation;
 use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
-use super::meta_command::ReturnCode;
+use super::meta_command::{MetaCommand, ReturnCode};
 use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
 use super::result::OpResult;
 use super::value::ToValue;
 
 /// The async counterpart of [`MetaClient`](super::MetaClient); the same
-/// request-builder surface over a tokio connection.
+/// request-builder surface over tokio connections.
 ///
 /// ```no_run
 /// # use memcache::exp::AsyncMetaClient;
@@ -28,7 +30,8 @@ use super::value::ToValue;
 /// # }
 /// ```
 pub struct AsyncMetaClient {
-    connection: AsyncMetaConnection,
+    connections: Vec<AsyncMetaConnection>,
+    hash_function: fn(&[u8]) -> u64,
 }
 
 impl AsyncMetaClient {
@@ -38,8 +41,41 @@ impl AsyncMetaClient {
         ))
     }
 
+    /// Connect to several servers; keys are distributed across them by the
+    /// hash function.
+    pub async fn connect_multiple<A: ToSocketAddrs>(
+        addrs: impl IntoIterator<Item = A>,
+    ) -> Result<AsyncMetaClient, MemcacheError> {
+        let mut connections = Vec::new();
+        for addr in addrs {
+            connections.push(AsyncMetaConnection::connect(addr).await?);
+        }
+        if connections.is_empty() {
+            return Err(ClientError::Error(Cow::Borrowed("at least one server address is required")).into());
+        }
+        Ok(AsyncMetaClient {
+            connections,
+            hash_function: default_hash_function,
+        })
+    }
+
     pub fn from_connection(connection: AsyncMetaConnection) -> AsyncMetaClient {
-        AsyncMetaClient { connection }
+        AsyncMetaClient {
+            connections: vec![connection],
+            hash_function: default_hash_function,
+        }
+    }
+
+    /// Replace the function that hashes keys; the server is then picked by
+    /// jump consistent hash over that value. The default hashes with
+    /// `DefaultHasher`.
+    pub fn with_hash_function(mut self, hash_function: fn(&[u8]) -> u64) -> AsyncMetaClient {
+        self.hash_function = hash_function;
+        self
+    }
+
+    fn connection_index(&self, key: &[u8]) -> usize {
+        jump_hash((self.hash_function)(key), self.connections.len())
     }
 
     /// Read a key.
@@ -76,16 +112,18 @@ impl AsyncMetaClient {
     /// for this.
     pub async fn run<O: Operation>(&mut self, operation: O) -> Result<O::Output, MemcacheError> {
         let command = operation.prepare()?;
-        let wire = parse_meta_result(self.connection.execute(&command).await?)?;
+        let index = self.connection_index(operation.key());
+        let wire = parse_meta_result(self.connections[index].execute(&command).await?)?;
         operation.parse(wire)
     }
 
-    /// Run several operations in one round trip over this connection.
+    /// Run several operations, split per server and pipelined with one
+    /// round trip per server.
     ///
     /// All commands are validated before anything is written and executed
-    /// independently in order; one operation's semantic outcome (miss, CAS
-    /// mismatch, ...) shows up in its own result and does not stop the rest.
-    /// This is not a transaction.
+    /// independently in order per server; one operation's semantic outcome
+    /// (miss, CAS mismatch, ...) shows up in its own result and does not
+    /// stop the rest. This is not a transaction.
     pub async fn run_batch(
         &mut self,
         operations: impl IntoIterator<Item = Op>,
@@ -97,30 +135,48 @@ impl AsyncMetaClient {
     async fn run_all<O: Operation>(&mut self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
         // Validate every operation before writing the first byte, so a bad
         // option never leaves half a batch on the wire.
-        let mut commands = Vec::with_capacity(operations.len());
+        let mut prepared: Vec<Option<MetaCommand>> = Vec::with_capacity(operations.len());
         for operation in operations {
-            commands.push(operation.prepare()?);
+            prepared.push(Some(operation.prepare()?));
         }
-        let responses = self.connection.execute_batch(&commands).await?;
-        operations
-            .iter()
-            .zip(responses)
-            .map(|(operation, response)| operation.parse(parse_meta_result(response)?))
-            .collect()
+        let mut groups: Vec<Vec<usize>> = vec![Vec::new(); self.connections.len()];
+        for (index, operation) in operations.iter().enumerate() {
+            groups[self.connection_index(operation.key())].push(index);
+        }
+        let mut outputs: Vec<Option<O::Output>> = (0..operations.len()).map(|_| None).collect();
+        for (server, indices) in groups.iter().enumerate() {
+            if indices.is_empty() {
+                continue;
+            }
+            let commands: Vec<MetaCommand> = indices.iter().map(|&index| prepared[index].take().unwrap()).collect();
+            let responses = self.connections[server].execute_batch(&commands).await?;
+            for (&index, response) in indices.iter().zip(responses) {
+                outputs[index] = Some(operations[index].parse(parse_meta_result(response)?)?);
+            }
+        }
+        Ok(outputs
+            .into_iter()
+            .map(|output| output.expect("batch executor left an operation unresolved"))
+            .collect())
     }
 
-    /// Round-trip an `mn` no-op; useful as a connection health check.
+    /// Round-trip an `mn` no-op on every server; useful as a connection
+    /// health check.
     pub async fn noop(&mut self) -> Result<(), MemcacheError> {
-        let response = self.connection.execute(&build_noop()).await?;
-        if response.rc != ReturnCode::Mn {
-            return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
+        for connection in &mut self.connections {
+            let response = connection.execute(&build_noop()).await?;
+            if response.rc != ReturnCode::Mn {
+                return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
+            }
         }
         Ok(())
     }
 
     /// Fetch `me` debug fields for a key; `None` on a miss.
     pub async fn debug(&mut self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
-        let response = self.connection.execute(&build_debug(key)?).await?;
+        let key = key.into();
+        let index = self.connection_index(&key);
+        let response = self.connections[index].execute(&build_debug(key)?).await?;
         parse_debug_result(&response)
     }
 }

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -1,24 +1,48 @@
-//! Blocking single-server client over the semantic layer.
+//! Blocking client over the semantic layer.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::net::ToSocketAddrs;
 
-use crate::error::{MemcacheError, ServerError};
+use crate::error::{ClientError, MemcacheError, ServerError};
 
 use super::connection::MetaConnection;
 use super::core::Operation;
 use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
-use super::meta_command::ReturnCode;
+use super::meta_command::{MetaCommand, ReturnCode};
 use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
 use super::result::OpResult;
 use super::value::ToValue;
 
-/// A blocking meta protocol client for a single server.
+pub(crate) fn default_hash_function(key: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Jump consistent hash (Lamping & Veach, 2014): maps a key hash to a
+/// bucket in `[0, buckets)`. When the bucket count changes from n to n+1,
+/// only 1/(n+1) of the keys move, so resizing the server list relocates as
+/// few keys as possible.
+pub(crate) fn jump_hash(mut key: u64, buckets: usize) -> usize {
+    let mut b: i64 = -1;
+    let mut j: i64 = 0;
+    while j < buckets as i64 {
+        b = j;
+        key = key.wrapping_mul(2862933555777941757).wrapping_add(1);
+        j = ((b + 1) as f64 * ((1u64 << 31) as f64 / ((key >> 33) + 1) as f64)) as i64;
+    }
+    b as usize
+}
+
+/// A blocking meta protocol client.
 ///
 /// The verbs return lazy [`Request`] builders; chain options and finish with
-/// [`send`](Request::send). Values are raw bytes. Serialization,
-/// multi-server routing and batching are not implemented yet.
+/// [`send`](Request::send). With multiple servers, keys are routed by a
+/// pluggable hash function and batches are split per server.
 ///
 /// ```no_run
 /// # use memcache::exp::MetaClient;
@@ -27,7 +51,8 @@ use super::value::ToValue;
 /// let result = client.get("foo").send().unwrap();
 /// ```
 pub struct MetaClient {
-    connection: MetaConnection,
+    connections: Vec<MetaConnection>,
+    hash_function: fn(&[u8]) -> u64,
 }
 
 impl MetaClient {
@@ -35,8 +60,39 @@ impl MetaClient {
         Ok(MetaClient::from_connection(MetaConnection::connect(addr)?))
     }
 
+    /// Connect to several servers; keys are distributed across them by the
+    /// hash function.
+    pub fn connect_multiple<A: ToSocketAddrs>(addrs: impl IntoIterator<Item = A>) -> Result<MetaClient, MemcacheError> {
+        let mut connections = Vec::new();
+        for addr in addrs {
+            connections.push(MetaConnection::connect(addr)?);
+        }
+        if connections.is_empty() {
+            return Err(ClientError::Error(Cow::Borrowed("at least one server address is required")).into());
+        }
+        Ok(MetaClient {
+            connections,
+            hash_function: default_hash_function,
+        })
+    }
+
     pub fn from_connection(connection: MetaConnection) -> MetaClient {
-        MetaClient { connection }
+        MetaClient {
+            connections: vec![connection],
+            hash_function: default_hash_function,
+        }
+    }
+
+    /// Replace the function that hashes keys; the server is then picked by
+    /// jump consistent hash over that value. The default hashes with
+    /// [`DefaultHasher`].
+    pub fn with_hash_function(mut self, hash_function: fn(&[u8]) -> u64) -> MetaClient {
+        self.hash_function = hash_function;
+        self
+    }
+
+    fn connection_index(&self, key: &[u8]) -> usize {
+        jump_hash((self.hash_function)(key), self.connections.len())
     }
 
     /// Read a key.
@@ -73,16 +129,18 @@ impl MetaClient {
     /// for this.
     pub fn run<O: Operation>(&mut self, operation: O) -> Result<O::Output, MemcacheError> {
         let command = operation.prepare()?;
-        let wire = parse_meta_result(self.connection.execute(&command)?)?;
+        let index = self.connection_index(operation.key());
+        let wire = parse_meta_result(self.connections[index].execute(&command)?)?;
         operation.parse(wire)
     }
 
-    /// Run several operations in one round trip over this connection.
+    /// Run several operations, split per server and pipelined with one
+    /// round trip per server.
     ///
     /// All commands are validated before anything is written and executed
-    /// independently in order; one operation's semantic outcome (miss, CAS
-    /// mismatch, ...) shows up in its own result and does not stop the rest.
-    /// This is not a transaction.
+    /// independently in order per server; one operation's semantic outcome
+    /// (miss, CAS mismatch, ...) shows up in its own result and does not
+    /// stop the rest. This is not a transaction.
     ///
     /// ```no_run
     /// # use memcache::exp::{Get, MetaClient, Set};
@@ -100,30 +158,48 @@ impl MetaClient {
     fn run_all<O: Operation>(&mut self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
         // Validate every operation before writing the first byte, so a bad
         // option never leaves half a batch on the wire.
-        let mut commands = Vec::with_capacity(operations.len());
+        let mut prepared: Vec<Option<MetaCommand>> = Vec::with_capacity(operations.len());
         for operation in operations {
-            commands.push(operation.prepare()?);
+            prepared.push(Some(operation.prepare()?));
         }
-        let responses = self.connection.execute_batch(&commands)?;
-        operations
-            .iter()
-            .zip(responses)
-            .map(|(operation, response)| operation.parse(parse_meta_result(response)?))
-            .collect()
+        let mut groups: Vec<Vec<usize>> = vec![Vec::new(); self.connections.len()];
+        for (index, operation) in operations.iter().enumerate() {
+            groups[self.connection_index(operation.key())].push(index);
+        }
+        let mut outputs: Vec<Option<O::Output>> = (0..operations.len()).map(|_| None).collect();
+        for (server, indices) in groups.iter().enumerate() {
+            if indices.is_empty() {
+                continue;
+            }
+            let commands: Vec<MetaCommand> = indices.iter().map(|&index| prepared[index].take().unwrap()).collect();
+            let responses = self.connections[server].execute_batch(&commands)?;
+            for (&index, response) in indices.iter().zip(responses) {
+                outputs[index] = Some(operations[index].parse(parse_meta_result(response)?)?);
+            }
+        }
+        Ok(outputs
+            .into_iter()
+            .map(|output| output.expect("batch executor left an operation unresolved"))
+            .collect())
     }
 
-    /// Round-trip an `mn` no-op; useful as a connection health check.
+    /// Round-trip an `mn` no-op on every server; useful as a connection
+    /// health check.
     pub fn noop(&mut self) -> Result<(), MemcacheError> {
-        let response = self.connection.execute(&build_noop())?;
-        if response.rc != ReturnCode::Mn {
-            return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
+        for connection in &mut self.connections {
+            let response = connection.execute(&build_noop())?;
+            if response.rc != ReturnCode::Mn {
+                return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
+            }
         }
         Ok(())
     }
 
     /// Fetch `me` debug fields for a key; `None` on a miss.
     pub fn debug(&mut self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
-        let response = self.connection.execute(&build_debug(key)?)?;
+        let key = key.into();
+        let index = self.connection_index(&key);
+        let response = self.connections[index].execute(&build_debug(key)?)?;
         parse_debug_result(&response)
     }
 }
@@ -170,6 +246,39 @@ mod tests {
             requests
         });
         (addr, handle)
+    }
+
+    /// Route keys by their first byte, so tests can steer each key to a
+    /// chosen server; `char_for` finds a leading character that jump-hashes
+    /// to the wanted bucket under two servers.
+    fn first_byte(key: &[u8]) -> u64 {
+        key[0] as u64
+    }
+
+    fn char_for(bucket: usize) -> char {
+        (b'0'..=b'z').find(|&byte| jump_hash(byte as u64, 2) == bucket).unwrap() as char
+    }
+
+    #[test]
+    fn jump_hash_properties() {
+        for key in 0..1000u64 {
+            assert_eq!(jump_hash(key, 1), 0);
+            // Growing n -> n+1 either keeps a key in place or moves it to
+            // the new bucket; nothing else may change.
+            for buckets in 1..10 {
+                let before = jump_hash(key, buckets);
+                let after = jump_hash(key, buckets + 1);
+                assert!(after == before || after == buckets);
+            }
+        }
+
+        let mut counts = [0usize; 4];
+        for key in 0..4000u64 {
+            counts[jump_hash(default_hash_function(&key.to_le_bytes()), 4)] += 1;
+        }
+        for &count in &counts {
+            assert!(count > 700, "unbalanced buckets: {:?}", counts);
+        }
     }
 
     #[test]
@@ -219,7 +328,7 @@ mod tests {
         let results = client
             .run_batch(vec![
                 Set::new("a", "1").ttl(60).into(),
-                Get::new("b").into(),
+                Get::new("a").into(),
                 Delete::new("c").into(),
             ])
             .unwrap();
@@ -231,7 +340,7 @@ mod tests {
         // All three commands were written before the first response was read.
         let requests = server.join().unwrap();
         assert_eq!(requests[0], b"ms a 1 F16 T60\r\n".to_vec());
-        assert_eq!(requests[1], b"mg b v f\r\n".to_vec());
+        assert_eq!(requests[1], b"mg a v f\r\n".to_vec());
         assert_eq!(requests[2], b"md c\r\n".to_vec());
     }
 
@@ -263,5 +372,70 @@ mod tests {
         let requests = server.join().unwrap();
         assert_eq!(requests[0], b"ms foo 3 F16 T60\r\n".to_vec());
         assert_eq!(requests[1], b"ma counter MD v D1\r\n".to_vec());
+    }
+
+    #[test]
+    fn multi_server_routes_by_key() {
+        let (addr0, server0) = scripted_server(vec![b"HD\r\n", b"MN\r\n"]);
+        let (addr1, server1) = scripted_server(vec![b"VA 1 f0\r\nx\r\n", b"MN\r\n"]);
+        let mut client = MetaClient::connect_multiple([addr0, addr1])
+            .unwrap()
+            .with_hash_function(first_byte);
+        let key0 = format!("{}a", char_for(0));
+        let key1 = format!("{}b", char_for(1));
+
+        assert!(client.set(&*key0, "v").send().unwrap().stored());
+        assert!(client.get(&*key1).send().unwrap().hit());
+        client.noop().unwrap();
+
+        assert_eq!(
+            server0.join().unwrap(),
+            vec![format!("ms {} 1 F16\r\n", key0).into_bytes(), b"mn\r\n".to_vec()]
+        );
+        assert_eq!(
+            server1.join().unwrap(),
+            vec![format!("mg {} v f\r\n", key1).into_bytes(), b"mn\r\n".to_vec()]
+        );
+    }
+
+    #[test]
+    fn multi_server_batch_splits_and_reorders() {
+        let (addr0, server0) = scripted_server(vec![b"EN\r\n"]);
+        let (addr1, server1) = scripted_server(vec![b"HD\r\n", b"NF\r\n"]);
+        let mut client = MetaClient::connect_multiple([addr0, addr1])
+            .unwrap()
+            .with_hash_function(first_byte);
+        let key_set = format!("{}a", char_for(1));
+        let key_get = format!("{}b", char_for(0));
+        let key_delete = format!("{}c", char_for(1));
+
+        // Interleaved across servers; results must come back in input order.
+        let results = client
+            .run_batch(vec![
+                Set::new(&*key_set, "v").into(),
+                Get::new(&*key_get).into(),
+                Delete::new(&*key_delete).into(),
+            ])
+            .unwrap();
+        assert!(results[0].as_mutation().unwrap().stored());
+        assert_eq!(results[1].as_get().unwrap().status, GetStatus::Miss);
+        assert_eq!(results[2].as_mutation().unwrap().status, MutationStatus::NotFound);
+
+        assert_eq!(
+            server0.join().unwrap(),
+            vec![format!("mg {} v f\r\n", key_get).into_bytes()]
+        );
+        assert_eq!(
+            server1.join().unwrap(),
+            vec![
+                format!("ms {} 1 F16\r\n", key_set).into_bytes(),
+                format!("md {}\r\n", key_delete).into_bytes(),
+            ]
+        );
+    }
+
+    #[test]
+    fn connect_multiple_rejects_empty() {
+        assert!(MetaClient::connect_multiple(Vec::<SocketAddr>::new()).is_err());
     }
 }

--- a/src/exp/core.rs
+++ b/src/exp/core.rs
@@ -34,6 +34,9 @@ pub trait Operation: sealed::Sealed {
     type Output;
 
     #[doc(hidden)]
+    fn key(&self) -> &[u8];
+
+    #[doc(hidden)]
     fn prepare(&self) -> Result<MetaCommand, MemcacheError>;
 
     #[doc(hidden)]
@@ -42,6 +45,10 @@ pub trait Operation: sealed::Sealed {
 
 impl Operation for Get {
     type Output = GetResult;
+
+    fn key(&self) -> &[u8] {
+        &self.key
+    }
 
     fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
         prepare_get(self)
@@ -55,6 +62,10 @@ impl Operation for Get {
 impl Operation for Set {
     type Output = MutationResult;
 
+    fn key(&self) -> &[u8] {
+        &self.key
+    }
+
     fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
         prepare_set(self)
     }
@@ -66,6 +77,10 @@ impl Operation for Set {
 
 impl Operation for Delete {
     type Output = MutationResult;
+
+    fn key(&self) -> &[u8] {
+        &self.key
+    }
 
     fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
         prepare_delete(self)
@@ -79,6 +94,10 @@ impl Operation for Delete {
 impl Operation for Arithmetic {
     type Output = ArithmeticResult;
 
+    fn key(&self) -> &[u8] {
+        &self.key
+    }
+
     fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
         prepare_arithmetic(self)
     }
@@ -90,6 +109,15 @@ impl Operation for Arithmetic {
 
 impl Operation for Op {
     type Output = OpResult;
+
+    fn key(&self) -> &[u8] {
+        match self {
+            Op::Get(operation) => &operation.key,
+            Op::Set(operation) => &operation.key,
+            Op::Delete(operation) => &operation.key,
+            Op::Arithmetic(operation) => &operation.key,
+        }
+    }
 
     fn prepare(&self) -> Result<MetaCommand, MemcacheError> {
         match self {

--- a/src/exp/meta_api.rs
+++ b/src/exp/meta_api.rs
@@ -74,35 +74,35 @@ impl FlagBuilder {
 /// Options for [`build_get`] (`mg`). Each field maps to one protocol flag.
 #[derive(Debug, Clone)]
 pub struct GetOptions {
-    /// `v` — return the item value.
+    /// `v` - return the item value.
     pub value: bool,
-    /// `f` — return the client flags.
+    /// `f` - return the client flags.
     pub return_client_flags: bool,
-    /// `c` — return the item CAS.
+    /// `c` - return the item CAS.
     pub return_cas: bool,
-    /// `t` — return the remaining TTL.
+    /// `t` - return the remaining TTL.
     pub return_ttl: bool,
-    /// `s` — return the stored size.
+    /// `s` - return the stored size.
     pub return_size: bool,
-    /// `l` — return seconds since last access.
+    /// `l` - return seconds since last access.
     pub return_last_access: bool,
-    /// `h` — return whether the item was hit before.
+    /// `h` - return whether the item was hit before.
     pub return_hit_before: bool,
-    /// `k` — echo the key in the response.
+    /// `k` - echo the key in the response.
     pub return_key: bool,
-    /// `u` — don't bump the item in the LRU.
+    /// `u` - don't bump the item in the LRU.
     pub no_lru_bump: bool,
-    /// `T<ttl>` — update the item TTL.
+    /// `T<ttl>` - update the item TTL.
     pub touch: Option<u32>,
-    /// `N<ttl>` — vivify a missing item with this TTL and grant a lease.
+    /// `N<ttl>` - vivify a missing item with this TTL and grant a lease.
     pub vivify_ttl: Option<u32>,
-    /// `R<ttl>` — grant a recache lease when the remaining TTL is below this.
+    /// `R<ttl>` - grant a recache lease when the remaining TTL is below this.
     pub recache_ttl: Option<u32>,
-    /// `C<cas>` — suppress the value when the item CAS still matches.
+    /// `C<cas>` - suppress the value when the item CAS still matches.
     pub unless_cas: Option<u64>,
-    /// `E<cas>` — replace the item CAS with this value.
+    /// `E<cas>` - replace the item CAS with this value.
     pub new_cas: Option<u64>,
-    /// `O<token>` — opaque token echoed back in the response.
+    /// `O<token>` - opaque token echoed back in the response.
     pub opaque: Option<Vec<u8>>,
 }
 
@@ -159,13 +159,13 @@ pub enum SetMode {
     /// Unconditional store (the protocol default, no mode flag).
     #[default]
     Set,
-    /// `ME` — store only when the item does not exist.
+    /// `ME` - store only when the item does not exist.
     Add,
-    /// `MR` — store only when the item exists.
+    /// `MR` - store only when the item exists.
     Replace,
-    /// `MA` — append raw bytes to the stored value.
+    /// `MA` - append raw bytes to the stored value.
     Append,
-    /// `MP` — prepend raw bytes to the stored value.
+    /// `MP` - prepend raw bytes to the stored value.
     Prepend,
 }
 
@@ -184,27 +184,27 @@ impl SetMode {
 /// Options for [`build_set`] (`ms`). Each field maps to one protocol flag.
 #[derive(Debug, Clone, Default)]
 pub struct SetOptions {
-    /// `F<flags>` — client flags stored with the item.
+    /// `F<flags>` - client flags stored with the item.
     pub client_flags: Option<u32>,
-    /// `T<ttl>` — item TTL.
+    /// `T<ttl>` - item TTL.
     pub ttl: Option<u32>,
-    /// `M<mode>` — storage mode.
+    /// `M<mode>` - storage mode.
     pub mode: SetMode,
-    /// `C<cas>` — store only when the item CAS matches.
+    /// `C<cas>` - store only when the item CAS matches.
     pub compare_cas: Option<u64>,
-    /// `E<cas>` — replace the item CAS with this value.
+    /// `E<cas>` - replace the item CAS with this value.
     pub new_cas: Option<u64>,
-    /// `I` — invalidate: mark the item stale instead of replacing it.
+    /// `I` - invalidate: mark the item stale instead of replacing it.
     pub invalidate: bool,
-    /// `N<ttl>` — for append/prepend, vivify a missing item with this TTL.
+    /// `N<ttl>` - for append/prepend, vivify a missing item with this TTL.
     pub vivify_ttl: Option<u32>,
-    /// `c` — return the new item CAS.
+    /// `c` - return the new item CAS.
     pub return_cas: bool,
-    /// `s` — return the stored size.
+    /// `s` - return the stored size.
     pub return_size: bool,
-    /// `k` — echo the key in the response.
+    /// `k` - echo the key in the response.
     pub return_key: bool,
-    /// `O<token>` — opaque token echoed back in the response.
+    /// `O<token>` - opaque token echoed back in the response.
     pub opaque: Option<Vec<u8>>,
 }
 
@@ -250,19 +250,19 @@ pub fn build_set(
 /// Options for [`build_delete`] (`md`). Each field maps to one protocol flag.
 #[derive(Debug, Clone, Default)]
 pub struct DeleteOptions {
-    /// `C<cas>` — delete only when the item CAS matches.
+    /// `C<cas>` - delete only when the item CAS matches.
     pub compare_cas: Option<u64>,
-    /// `E<cas>` — for invalidate, replace the item CAS with this value.
+    /// `E<cas>` - for invalidate, replace the item CAS with this value.
     pub new_cas: Option<u64>,
-    /// `I` — invalidate: mark the item stale instead of removing it.
+    /// `I` - invalidate: mark the item stale instead of removing it.
     pub invalidate: bool,
-    /// `T<ttl>` — for invalidate, the TTL the stale item keeps.
+    /// `T<ttl>` - for invalidate, the TTL the stale item keeps.
     pub ttl: Option<u32>,
-    /// `x` — drop the value but keep the item.
+    /// `x` - drop the value but keep the item.
     pub drop_value: bool,
-    /// `k` — echo the key in the response.
+    /// `k` - echo the key in the response.
     pub return_key: bool,
-    /// `O<token>` — opaque token echoed back in the response.
+    /// `O<token>` - opaque token echoed back in the response.
     pub opaque: Option<Vec<u8>>,
 }
 
@@ -290,7 +290,7 @@ pub enum ArithmeticMode {
     /// Increment (the protocol default, no mode flag).
     #[default]
     Increment,
-    /// `MD` — decrement.
+    /// `MD` - decrement.
     Decrement,
 }
 
@@ -298,29 +298,29 @@ pub enum ArithmeticMode {
 /// flag.
 #[derive(Debug, Clone)]
 pub struct ArithmeticOptions {
-    /// `D<delta>` — the delta to apply (the server defaults to 1).
+    /// `D<delta>` - the delta to apply (the server defaults to 1).
     pub delta: Option<u64>,
-    /// `M<mode>` — increment or decrement.
+    /// `M<mode>` - increment or decrement.
     pub mode: ArithmeticMode,
-    /// `J<value>` — initial value when vivifying a missing item.
+    /// `J<value>` - initial value when vivifying a missing item.
     pub initial: Option<u64>,
-    /// `N<ttl>` — vivify a missing item with this TTL.
+    /// `N<ttl>` - vivify a missing item with this TTL.
     pub initial_ttl: Option<u32>,
-    /// `T<ttl>` — update the item TTL.
+    /// `T<ttl>` - update the item TTL.
     pub ttl: Option<u32>,
-    /// `C<cas>` — apply only when the item CAS matches.
+    /// `C<cas>` - apply only when the item CAS matches.
     pub compare_cas: Option<u64>,
-    /// `E<cas>` — replace the item CAS with this value.
+    /// `E<cas>` - replace the item CAS with this value.
     pub new_cas: Option<u64>,
-    /// `v` — return the new value.
+    /// `v` - return the new value.
     pub return_value: bool,
-    /// `t` — return the remaining TTL.
+    /// `t` - return the remaining TTL.
     pub return_ttl: bool,
-    /// `c` — return the new item CAS.
+    /// `c` - return the new item CAS.
     pub return_cas: bool,
-    /// `k` — echo the key in the response.
+    /// `k` - echo the key in the response.
     pub return_key: bool,
-    /// `O<token>` — opaque token echoed back in the response.
+    /// `O<token>` - opaque token echoed back in the response.
     pub opaque: Option<Vec<u8>>,
 }
 
@@ -395,27 +395,27 @@ pub struct MetaCommandResult {
     pub rc: ReturnCode,
     /// The raw data block, if any.
     pub value: Option<Vec<u8>>,
-    /// `c` — item CAS.
+    /// `c` - item CAS.
     pub cas: Option<u64>,
-    /// `t` — remaining TTL (`-1` means unlimited).
+    /// `t` - remaining TTL (`-1` means unlimited).
     pub ttl: Option<i64>,
-    /// `f` — client flags.
+    /// `f` - client flags.
     pub client_flags: Option<u32>,
-    /// `s` — stored size.
+    /// `s` - stored size.
     pub size: Option<u64>,
-    /// `l` — seconds since last access.
+    /// `l` - seconds since last access.
     pub last_access: Option<u64>,
-    /// `h` — whether the item was hit before.
+    /// `h` - whether the item was hit before.
     pub hit_before: Option<bool>,
-    /// `k` — the echoed key (base64-decoded when the `b` flag is present).
+    /// `k` - the echoed key (base64-decoded when the `b` flag is present).
     pub key: Option<Vec<u8>>,
-    /// `O` — the echoed opaque token.
+    /// `O` - the echoed opaque token.
     pub opaque: Option<Vec<u8>>,
-    /// `W` — this client won a vivify/recache lease.
+    /// `W` - this client won a vivify/recache lease.
     pub won: bool,
-    /// `Z` — another client holds the lease.
+    /// `Z` - another client holds the lease.
     pub busy: bool,
-    /// `X` — the value is stale.
+    /// `X` - the value is stale.
     pub stale: bool,
     /// The raw response flag tokens.
     pub flags: Vec<Vec<u8>>,

--- a/src/exp/meta_command.rs
+++ b/src/exp/meta_command.rs
@@ -108,17 +108,17 @@ pub(crate) fn encode_key(key: &[u8]) -> Result<(Cow<'_, [u8]>, bool), MemcacheEr
 /// A meta protocol command code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetaOp {
-    /// `mg` — meta get.
+    /// `mg` - meta get.
     Get,
-    /// `ms` — meta set.
+    /// `ms` - meta set.
     Set,
-    /// `md` — meta delete.
+    /// `md` - meta delete.
     Delete,
-    /// `ma` — meta arithmetic.
+    /// `ma` - meta arithmetic.
     Arithmetic,
-    /// `mn` — meta no-op, used as a pipeline barrier.
+    /// `mn` - meta no-op, used as a pipeline barrier.
     Noop,
-    /// `me` — meta debug.
+    /// `me` - meta debug.
     Debug,
 }
 
@@ -138,21 +138,21 @@ impl MetaOp {
 /// A meta protocol response return code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReturnCode {
-    /// `HD` — success without a value block.
+    /// `HD` - success without a value block.
     Hd,
-    /// `VA` — success with a value block.
+    /// `VA` - success with a value block.
     Va,
-    /// `EN` — miss.
+    /// `EN` - miss.
     En,
-    /// `NS` — not stored.
+    /// `NS` - not stored.
     Ns,
-    /// `EX` — item exists (CAS mismatch).
+    /// `EX` - item exists (CAS mismatch).
     Ex,
-    /// `NF` — not found.
+    /// `NF` - not found.
     Nf,
-    /// `MN` — no-op marker.
+    /// `MN` - no-op marker.
     Mn,
-    /// `ME` — debug line.
+    /// `ME` - debug line.
     Me,
 }
 

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -6,7 +6,7 @@ Everything in this module is experimental and may change without notice.
 
 The module is layered bottom-up:
 
-- [`MetaCommand`] / [`MetaResponse`]: framing — request assembly and response
+- [`MetaCommand`] / [`MetaResponse`]: framing - request assembly and response
   header parsing, including automatic base64 encoding of binary keys.
 - `build_*` / `parse_*` and the `*Options` structs: a typed 1:1 mapping of the
   protocol where every option field corresponds to exactly one protocol flag.
@@ -21,11 +21,14 @@ The module is layered bottom-up:
 
 Several operations can run in one round trip: `run_batch` takes
 heterogeneous [`Op`] values and returns [`OpResult`]s. Batched operations
-execute independently and in order on one connection — a batch is not a
+execute independently and in order per server - a batch is not a
 transaction.
 
-Transports are TCP only. Serialization and multi-server routing are not
-implemented yet.
+Clients connected to several servers (`connect_multiple`) route each key by
+a pluggable hash function and split batches per server, one round trip
+each.
+
+Transports are TCP only.
 
 # Example
 

--- a/src/exp/operation.rs
+++ b/src/exp/operation.rs
@@ -164,7 +164,7 @@ impl Get {
 pub struct Set {
     pub key: Vec<u8>,
     pub value: Vec<u8>,
-    /// `F<flags>` — client flags stored with the item, from [`ToValue`].
+    /// `F<flags>` - client flags stored with the item, from [`ToValue`].
     pub client_flags: u32,
     pub ttl: Option<u32>,
     pub mode: SetMode,

--- a/src/exp/request.rs
+++ b/src/exp/request.rs
@@ -5,7 +5,7 @@
 //! operation's builders; nothing touches the network until
 //! [`send`](Request::send). `Request` is generic over the client, so the
 //! option surface is written once and shared by the blocking and tokio
-//! clients — only `send` is implemented per client.
+//! clients - only `send` is implemented per client.
 
 use super::meta_api::SetMode;
 use super::operation::{Arithmetic, Delete, Get, Meta, Set};

--- a/src/exp/value.rs
+++ b/src/exp/value.rs
@@ -9,8 +9,8 @@
 //! [`FLAG_BYTES`] (zero) for everything else.
 //!
 //! Decoding is driven purely by the requested type; the built-in
-//! implementations ignore the stored flags, so anything a client wrote —
-//! flagged or not — decodes as long as the bytes parse. Flags will start
+//! implementations ignore the stored flags, so anything a client wrote -
+//! flagged or not - decodes as long as the bytes parse. Flags will start
 //! participating in decoding once flag-bearing encodings (compression,
 //! JSON, ...) are supported; custom implementations can already use them.
 

--- a/tests/test_exp.rs
+++ b/tests/test_exp.rs
@@ -192,6 +192,33 @@ fn exp_typed_values() {
 }
 
 #[test]
+fn exp_multi_server() {
+    let mut client = MetaClient::connect_multiple(["localhost:12345", "localhost:12346"]).unwrap();
+    client.noop().unwrap();
+
+    let keys: Vec<String> = (0..20).map(|_| gen_random_key()).collect();
+    for key in &keys {
+        assert!(client.set(key.as_str(), key.as_str()).send().unwrap().stored());
+    }
+    for key in &keys {
+        let fetched = client.get(key.as_str()).send().unwrap();
+        assert_eq!(fetched.value.as_deref(), Some(key.as_bytes()));
+    }
+
+    // A batch spanning both servers comes back in input order.
+    let results = client
+        .run_batch(keys.iter().map(|key| Get::new(key.as_str()).into()))
+        .unwrap();
+    for (key, result) in keys.iter().zip(&results) {
+        assert_eq!(result.as_get().unwrap().value.as_deref(), Some(key.as_bytes()));
+    }
+
+    for key in &keys {
+        assert!(client.delete(key.as_str()).send().unwrap().stored());
+    }
+}
+
+#[test]
 fn exp_debug() {
     let mut client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();


### PR DESCRIPTION
Route keys across several servers in the exp clients.

- `connect_multiple` on both clients; keys are placed by jump consistent hash (Lamping & Veach) over a pluggable key hash function, so resizing the server list relocates only ~1/n of the keys
- `run_batch` splits operations per server (one pipelined round trip each) and returns results in input order; validation still happens before anything is written
- `noop` now health-checks every server; `debug` routes by key
- The `Operation` trait gained a `key()` accessor to support routing