### PR TITLE
Add connection pooling to exp module

### DIFF
--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -2,14 +2,16 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 
-use tokio::net::ToSocketAddrs;
+use tokio::net::{ToSocketAddrs, lookup_host};
 
 use crate::error::{ClientError, MemcacheError, ServerError};
 
 use super::async_connection::AsyncMetaConnection;
-use super::client::{default_hash_function, jump_hash};
-use super::core::Operation;
+use super::client::{DEFAULT_MAX_IDLE, default_hash_function, jump_hash};
+use super::core::{self, Operation};
 use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
 use super::meta_command::{MetaCommand, ReturnCode};
 use super::operation::{Arithmetic, Delete, Get, Op, Set};
@@ -17,90 +19,130 @@ use super::request::Request;
 use super::result::OpResult;
 use super::value::ToValue;
 
+/// One server: its resolved addresses and a stack of idle connections.
+/// The mutex is only held to pop/push, never across I/O.
+struct AsyncServer {
+    addrs: Vec<SocketAddr>,
+    idle: Mutex<Vec<AsyncMetaConnection>>,
+}
+
+impl AsyncServer {
+    async fn checkout(&self) -> Result<AsyncMetaConnection, MemcacheError> {
+        let reused = self.idle.lock().unwrap().pop();
+        if let Some(connection) = reused {
+            return Ok(connection);
+        }
+        AsyncMetaConnection::connect(self.addrs.as_slice()).await
+    }
+
+    fn put_back(&self, connection: AsyncMetaConnection, max_idle: usize) {
+        let mut idle = self.idle.lock().unwrap();
+        if idle.len() < max_idle {
+            idle.push(connection);
+        }
+    }
+}
+
 /// The async counterpart of [`MetaClient`](super::MetaClient); the same
-/// request-builder surface over tokio connections.
+/// request-builder surface and pooling behavior over tokio connections.
+/// Cheap to clone and shareable across tasks.
 ///
 /// ```no_run
 /// # use memcache::exp::AsyncMetaClient;
 /// # async fn example() -> Result<(), memcache::MemcacheError> {
-/// let mut client = AsyncMetaClient::connect("127.0.0.1:11211").await?;
+/// let client = AsyncMetaClient::connect("127.0.0.1:11211").await?;
 /// client.set("foo", "bar").ttl(60).send().await?;
 /// let result = client.get("foo").send().await?;
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Clone)]
 pub struct AsyncMetaClient {
-    connections: Vec<AsyncMetaConnection>,
+    servers: Arc<Vec<AsyncServer>>,
     hash_function: fn(&[u8]) -> u64,
+    max_idle: usize,
 }
 
 impl AsyncMetaClient {
     pub async fn connect<A: ToSocketAddrs>(addr: A) -> Result<AsyncMetaClient, MemcacheError> {
-        Ok(AsyncMetaClient::from_connection(
-            AsyncMetaConnection::connect(addr).await?,
-        ))
+        AsyncMetaClient::connect_multiple([addr]).await
     }
 
     /// Connect to several servers; keys are distributed across them by the
-    /// hash function.
+    /// hash function. One connection per server is dialed up front so
+    /// connection errors surface here.
     pub async fn connect_multiple<A: ToSocketAddrs>(
         addrs: impl IntoIterator<Item = A>,
     ) -> Result<AsyncMetaClient, MemcacheError> {
-        let mut connections = Vec::new();
+        let mut servers = Vec::new();
         for addr in addrs {
-            connections.push(AsyncMetaConnection::connect(addr).await?);
+            let resolved: Vec<SocketAddr> = lookup_host(addr).await?.collect();
+            if resolved.is_empty() {
+                return Err(ClientError::Error(Cow::Borrowed("address resolved to no socket addresses")).into());
+            }
+            let server = AsyncServer {
+                addrs: resolved,
+                idle: Mutex::new(Vec::new()),
+            };
+            let connection = AsyncMetaConnection::connect(server.addrs.as_slice()).await?;
+            server.idle.lock().unwrap().push(connection);
+            servers.push(server);
         }
-        if connections.is_empty() {
+        if servers.is_empty() {
             return Err(ClientError::Error(Cow::Borrowed("at least one server address is required")).into());
         }
         Ok(AsyncMetaClient {
-            connections,
+            servers: Arc::new(servers),
             hash_function: default_hash_function,
+            max_idle: DEFAULT_MAX_IDLE,
         })
-    }
-
-    pub fn from_connection(connection: AsyncMetaConnection) -> AsyncMetaClient {
-        AsyncMetaClient {
-            connections: vec![connection],
-            hash_function: default_hash_function,
-        }
     }
 
     /// Replace the function that hashes keys; the server is then picked by
     /// jump consistent hash over that value. The default hashes with
-    /// `DefaultHasher`.
+    /// `DefaultHasher`. Configure before cloning: clones share connections
+    /// but not this setting.
     pub fn with_hash_function(mut self, hash_function: fn(&[u8]) -> u64) -> AsyncMetaClient {
         self.hash_function = hash_function;
         self
     }
 
+    /// Cap how many idle connections each server retains (default 8).
+    /// Concurrency above the cap dials extra connections, which are dropped
+    /// when returned. Configure before cloning: clones share connections
+    /// but not this setting.
+    pub fn with_max_idle(mut self, max_idle: usize) -> AsyncMetaClient {
+        self.max_idle = max_idle;
+        self
+    }
+
     fn connection_index(&self, key: &[u8]) -> usize {
-        jump_hash((self.hash_function)(key), self.connections.len())
+        jump_hash((self.hash_function)(key), self.servers.len())
     }
 
     /// Read a key.
-    pub fn get(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Get> {
+    pub fn get(&self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Get> {
         Request::new(self, Get::new(key))
     }
 
     /// Store a value under a key; the value is encoded via
     /// [`ToValue`](super::ToValue).
-    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl ToValue) -> Request<'_, AsyncMetaClient, Set> {
+    pub fn set(&self, key: impl Into<Vec<u8>>, value: impl ToValue) -> Request<'_, AsyncMetaClient, Set> {
         Request::new(self, Set::new(key, value))
     }
 
     /// Delete a key.
-    pub fn delete(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Delete> {
+    pub fn delete(&self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Delete> {
         Request::new(self, Delete::new(key))
     }
 
     /// Increment a counter (delta defaults to 1).
-    pub fn increment(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Arithmetic> {
+    pub fn increment(&self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Arithmetic> {
         Request::new(self, Arithmetic::new(key))
     }
 
     /// Decrement a counter (delta defaults to 1); saturates at zero.
-    pub fn decrement(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Arithmetic> {
+    pub fn decrement(&self, key: impl Into<Vec<u8>>) -> Request<'_, AsyncMetaClient, Arithmetic> {
         let operation = Arithmetic {
             mode: ArithmeticMode::Decrement,
             ..Arithmetic::new(key)
@@ -110,11 +152,15 @@ impl AsyncMetaClient {
 
     /// Run a standalone operation value; [`send`](Request::send) is sugar
     /// for this.
-    pub async fn run<O: Operation>(&mut self, operation: O) -> Result<O::Output, MemcacheError> {
+    pub async fn run<O: Operation>(&self, operation: O) -> Result<O::Output, MemcacheError> {
         let command = operation.prepare()?;
-        let index = self.connection_index(operation.key());
-        let wire = parse_meta_result(self.connections[index].execute(&command).await?)?;
-        operation.parse(wire)
+        let server = &self.servers[self.connection_index(operation.key())];
+        let mut connection = server.checkout().await?;
+        // A failed exchange leaves the stream in an unknown state, so the
+        // connection is dropped instead of returned to the pool.
+        let response = connection.execute(&command).await?;
+        server.put_back(connection, self.max_idle);
+        operation.parse(parse_meta_result(response)?)
     }
 
     /// Run several operations, split per server and pipelined with one
@@ -124,32 +170,26 @@ impl AsyncMetaClient {
     /// independently in order per server; one operation's semantic outcome
     /// (miss, CAS mismatch, ...) shows up in its own result and does not
     /// stop the rest. This is not a transaction.
-    pub async fn run_batch(
-        &mut self,
-        operations: impl IntoIterator<Item = Op>,
-    ) -> Result<Vec<OpResult>, MemcacheError> {
+    pub async fn run_batch(&self, operations: impl IntoIterator<Item = Op>) -> Result<Vec<OpResult>, MemcacheError> {
         let operations: Vec<Op> = operations.into_iter().collect();
         self.run_all(&operations).await
     }
 
-    async fn run_all<O: Operation>(&mut self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
-        // Validate every operation before writing the first byte, so a bad
-        // option never leaves half a batch on the wire.
-        let mut prepared: Vec<Option<MetaCommand>> = Vec::with_capacity(operations.len());
-        for operation in operations {
-            prepared.push(Some(operation.prepare()?));
-        }
-        let mut groups: Vec<Vec<usize>> = vec![Vec::new(); self.connections.len()];
-        for (index, operation) in operations.iter().enumerate() {
-            groups[self.connection_index(operation.key())].push(index);
-        }
+    async fn run_all<O: Operation>(&self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
+        let mut plan = core::plan(operations, self.servers.len(), |key| self.connection_index(key))?;
         let mut outputs: Vec<Option<O::Output>> = (0..operations.len()).map(|_| None).collect();
-        for (server, indices) in groups.iter().enumerate() {
+        for (server, indices) in plan.groups.iter().enumerate() {
             if indices.is_empty() {
                 continue;
             }
-            let commands: Vec<MetaCommand> = indices.iter().map(|&index| prepared[index].take().unwrap()).collect();
-            let responses = self.connections[server].execute_batch(&commands).await?;
+            let commands: Vec<MetaCommand> = indices
+                .iter()
+                .map(|&index| plan.commands[index].take().unwrap())
+                .collect();
+            let server = &self.servers[server];
+            let mut connection = server.checkout().await?;
+            let responses = connection.execute_batch(&commands).await?;
+            server.put_back(connection, self.max_idle);
             for (&index, response) in indices.iter().zip(responses) {
                 outputs[index] = Some(operations[index].parse(parse_meta_result(response)?)?);
             }
@@ -162,9 +202,11 @@ impl AsyncMetaClient {
 
     /// Round-trip an `mn` no-op on every server; useful as a connection
     /// health check.
-    pub async fn noop(&mut self) -> Result<(), MemcacheError> {
-        for connection in &mut self.connections {
+    pub async fn noop(&self) -> Result<(), MemcacheError> {
+        for server in self.servers.iter() {
+            let mut connection = server.checkout().await?;
             let response = connection.execute(&build_noop()).await?;
+            server.put_back(connection, self.max_idle);
             if response.rc != ReturnCode::Mn {
                 return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
             }
@@ -173,10 +215,13 @@ impl AsyncMetaClient {
     }
 
     /// Fetch `me` debug fields for a key; `None` on a miss.
-    pub async fn debug(&mut self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
+    pub async fn debug(&self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
         let key = key.into();
-        let index = self.connection_index(&key);
-        let response = self.connections[index].execute(&build_debug(key)?).await?;
+        let server = &self.servers[self.connection_index(&key)];
+        let command = build_debug(key)?;
+        let mut connection = server.checkout().await?;
+        let response = connection.execute(&command).await?;
+        server.put_back(connection, self.max_idle);
         parse_debug_result(&response)
     }
 }

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -4,18 +4,21 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::{Arc, Mutex};
 
 use crate::error::{ClientError, MemcacheError, ServerError};
 
 use super::connection::MetaConnection;
-use super::core::Operation;
+use super::core::{self, Operation};
 use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
 use super::meta_command::{MetaCommand, ReturnCode};
 use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
 use super::result::OpResult;
 use super::value::ToValue;
+
+pub(crate) const DEFAULT_MAX_IDLE: usize = 8;
 
 pub(crate) fn default_hash_function(key: &[u8]) -> u64 {
     let mut hasher = DefaultHasher::new();
@@ -38,86 +41,156 @@ pub(crate) fn jump_hash(mut key: u64, buckets: usize) -> usize {
     b as usize
 }
 
+pub(crate) fn resolve<A: ToSocketAddrs>(addr: A) -> Result<Vec<SocketAddr>, MemcacheError> {
+    let addrs: Vec<SocketAddr> = addr.to_socket_addrs()?.collect();
+    if addrs.is_empty() {
+        return Err(ClientError::Error(Cow::Borrowed("address resolved to no socket addresses")).into());
+    }
+    Ok(addrs)
+}
+
+/// One server: its resolved addresses and a stack of idle connections.
+///
+/// Checkout pops an idle connection or dials a new one; there is no cap on
+/// concurrent connections, only on how many idle ones are retained.
+struct Server {
+    addrs: Vec<SocketAddr>,
+    idle: Mutex<Vec<MetaConnection>>,
+}
+
+impl Server {
+    fn checkout(&self) -> Result<MetaConnection, MemcacheError> {
+        if let Some(connection) = self.idle.lock().unwrap().pop() {
+            return Ok(connection);
+        }
+        MetaConnection::connect(self.addrs.as_slice())
+    }
+
+    fn put_back(&self, connection: MetaConnection, max_idle: usize) {
+        let mut idle = self.idle.lock().unwrap();
+        if idle.len() < max_idle {
+            idle.push(connection);
+        }
+    }
+}
+
 /// A blocking meta protocol client.
 ///
 /// The verbs return lazy [`Request`] builders; chain options and finish with
-/// [`send`](Request::send). With multiple servers, keys are routed by a
-/// pluggable hash function and batches are split per server.
+/// [`send`](Request::send). With multiple servers, keys are routed by jump
+/// consistent hash over a pluggable key hash and batches are split per
+/// server.
+///
+/// The client is cheap to clone and shareable across threads; clones share
+/// the connection pools. Each server keeps a stack of idle connections
+/// (bounded by [`with_max_idle`](Self::with_max_idle)); a connection that
+/// fails mid-exchange is dropped instead of being reused, and the next
+/// operation dials a fresh one.
 ///
 /// ```no_run
 /// # use memcache::exp::MetaClient;
-/// let mut client = MetaClient::connect("127.0.0.1:11211").unwrap();
+/// let client = MetaClient::connect("127.0.0.1:11211").unwrap();
 /// client.set("foo", "bar").ttl(60).send().unwrap();
 /// let result = client.get("foo").send().unwrap();
 /// ```
+#[derive(Clone)]
 pub struct MetaClient {
-    connections: Vec<MetaConnection>,
+    servers: Arc<Vec<Server>>,
     hash_function: fn(&[u8]) -> u64,
+    max_idle: usize,
 }
 
 impl MetaClient {
     pub fn connect<A: ToSocketAddrs>(addr: A) -> Result<MetaClient, MemcacheError> {
-        Ok(MetaClient::from_connection(MetaConnection::connect(addr)?))
+        MetaClient::connect_multiple([addr])
     }
 
     /// Connect to several servers; keys are distributed across them by the
-    /// hash function.
+    /// hash function. One connection per server is dialed up front so
+    /// connection errors surface here.
     pub fn connect_multiple<A: ToSocketAddrs>(addrs: impl IntoIterator<Item = A>) -> Result<MetaClient, MemcacheError> {
-        let mut connections = Vec::new();
+        let mut servers = Vec::new();
         for addr in addrs {
-            connections.push(MetaConnection::connect(addr)?);
+            let server = Server {
+                addrs: resolve(addr)?,
+                idle: Mutex::new(Vec::new()),
+            };
+            let connection = MetaConnection::connect(server.addrs.as_slice())?;
+            server.idle.lock().unwrap().push(connection);
+            servers.push(server);
         }
-        if connections.is_empty() {
+        if servers.is_empty() {
             return Err(ClientError::Error(Cow::Borrowed("at least one server address is required")).into());
         }
         Ok(MetaClient {
-            connections,
+            servers: Arc::new(servers),
             hash_function: default_hash_function,
+            max_idle: DEFAULT_MAX_IDLE,
         })
-    }
-
-    pub fn from_connection(connection: MetaConnection) -> MetaClient {
-        MetaClient {
-            connections: vec![connection],
-            hash_function: default_hash_function,
-        }
     }
 
     /// Replace the function that hashes keys; the server is then picked by
     /// jump consistent hash over that value. The default hashes with
-    /// [`DefaultHasher`].
+    /// [`DefaultHasher`]. Configure before cloning: clones share
+    /// connections but not this setting.
     pub fn with_hash_function(mut self, hash_function: fn(&[u8]) -> u64) -> MetaClient {
         self.hash_function = hash_function;
         self
     }
 
+    /// Cap how many idle connections each server retains (default 8).
+    /// Concurrency above the cap dials extra connections, which are dropped
+    /// when returned. Configure before cloning: clones share connections
+    /// but not this setting.
+    pub fn with_max_idle(mut self, max_idle: usize) -> MetaClient {
+        self.max_idle = max_idle;
+        self
+    }
+
     fn connection_index(&self, key: &[u8]) -> usize {
-        jump_hash((self.hash_function)(key), self.connections.len())
+        jump_hash((self.hash_function)(key), self.servers.len())
+    }
+
+    /// Check out a connection, run one transport exchange on it and return
+    /// it to the pool. A failed exchange leaves the stream in an unknown
+    /// state, so the connection is dropped instead of returned.
+    fn with_connection<T>(
+        &self,
+        server: usize,
+        exchange: impl FnOnce(&mut MetaConnection) -> Result<T, MemcacheError>,
+    ) -> Result<T, MemcacheError> {
+        let server = &self.servers[server];
+        let mut connection = server.checkout()?;
+        let result = exchange(&mut connection);
+        if result.is_ok() {
+            server.put_back(connection, self.max_idle);
+        }
+        result
     }
 
     /// Read a key.
-    pub fn get(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Get> {
+    pub fn get(&self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Get> {
         Request::new(self, Get::new(key))
     }
 
     /// Store a value under a key; the value is encoded via
     /// [`ToValue`](super::ToValue).
-    pub fn set(&mut self, key: impl Into<Vec<u8>>, value: impl ToValue) -> Request<'_, MetaClient, Set> {
+    pub fn set(&self, key: impl Into<Vec<u8>>, value: impl ToValue) -> Request<'_, MetaClient, Set> {
         Request::new(self, Set::new(key, value))
     }
 
     /// Delete a key.
-    pub fn delete(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Delete> {
+    pub fn delete(&self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Delete> {
         Request::new(self, Delete::new(key))
     }
 
     /// Increment a counter (delta defaults to 1).
-    pub fn increment(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Arithmetic> {
+    pub fn increment(&self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Arithmetic> {
         Request::new(self, Arithmetic::new(key))
     }
 
     /// Decrement a counter (delta defaults to 1); saturates at zero.
-    pub fn decrement(&mut self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Arithmetic> {
+    pub fn decrement(&self, key: impl Into<Vec<u8>>) -> Request<'_, MetaClient, Arithmetic> {
         let operation = Arithmetic {
             mode: ArithmeticMode::Decrement,
             ..Arithmetic::new(key)
@@ -127,11 +200,11 @@ impl MetaClient {
 
     /// Run a standalone operation value; [`send`](Request::send) is sugar
     /// for this.
-    pub fn run<O: Operation>(&mut self, operation: O) -> Result<O::Output, MemcacheError> {
+    pub fn run<O: Operation>(&self, operation: O) -> Result<O::Output, MemcacheError> {
         let command = operation.prepare()?;
         let index = self.connection_index(operation.key());
-        let wire = parse_meta_result(self.connections[index].execute(&command)?)?;
-        operation.parse(wire)
+        let response = self.with_connection(index, |connection| connection.execute(&command))?;
+        operation.parse(parse_meta_result(response)?)
     }
 
     /// Run several operations, split per server and pipelined with one
@@ -144,35 +217,29 @@ impl MetaClient {
     ///
     /// ```no_run
     /// # use memcache::exp::{Get, MetaClient, Set};
-    /// # let mut client = MetaClient::connect("127.0.0.1:11211").unwrap();
+    /// # let client = MetaClient::connect("127.0.0.1:11211").unwrap();
     /// let results = client.run_batch(vec![
     ///     Set::new("foo", "bar").ttl(60).into(),
     ///     Get::new("baz").into(),
     /// ]).unwrap();
     /// ```
-    pub fn run_batch(&mut self, operations: impl IntoIterator<Item = Op>) -> Result<Vec<OpResult>, MemcacheError> {
+    pub fn run_batch(&self, operations: impl IntoIterator<Item = Op>) -> Result<Vec<OpResult>, MemcacheError> {
         let operations: Vec<Op> = operations.into_iter().collect();
         self.run_all(&operations)
     }
 
-    fn run_all<O: Operation>(&mut self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
-        // Validate every operation before writing the first byte, so a bad
-        // option never leaves half a batch on the wire.
-        let mut prepared: Vec<Option<MetaCommand>> = Vec::with_capacity(operations.len());
-        for operation in operations {
-            prepared.push(Some(operation.prepare()?));
-        }
-        let mut groups: Vec<Vec<usize>> = vec![Vec::new(); self.connections.len()];
-        for (index, operation) in operations.iter().enumerate() {
-            groups[self.connection_index(operation.key())].push(index);
-        }
+    fn run_all<O: Operation>(&self, operations: &[O]) -> Result<Vec<O::Output>, MemcacheError> {
+        let mut plan = core::plan(operations, self.servers.len(), |key| self.connection_index(key))?;
         let mut outputs: Vec<Option<O::Output>> = (0..operations.len()).map(|_| None).collect();
-        for (server, indices) in groups.iter().enumerate() {
+        for (server, indices) in plan.groups.iter().enumerate() {
             if indices.is_empty() {
                 continue;
             }
-            let commands: Vec<MetaCommand> = indices.iter().map(|&index| prepared[index].take().unwrap()).collect();
-            let responses = self.connections[server].execute_batch(&commands)?;
+            let commands: Vec<MetaCommand> = indices
+                .iter()
+                .map(|&index| plan.commands[index].take().unwrap())
+                .collect();
+            let responses = self.with_connection(server, |connection| connection.execute_batch(&commands))?;
             for (&index, response) in indices.iter().zip(responses) {
                 outputs[index] = Some(operations[index].parse(parse_meta_result(response)?)?);
             }
@@ -185,9 +252,9 @@ impl MetaClient {
 
     /// Round-trip an `mn` no-op on every server; useful as a connection
     /// health check.
-    pub fn noop(&mut self) -> Result<(), MemcacheError> {
-        for connection in &mut self.connections {
-            let response = connection.execute(&build_noop())?;
+    pub fn noop(&self) -> Result<(), MemcacheError> {
+        for server in 0..self.servers.len() {
+            let response = self.with_connection(server, |connection| connection.execute(&build_noop()))?;
             if response.rc != ReturnCode::Mn {
                 return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
             }
@@ -196,10 +263,11 @@ impl MetaClient {
     }
 
     /// Fetch `me` debug fields for a key; `None` on a miss.
-    pub fn debug(&mut self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
+    pub fn debug(&self, key: impl Into<Vec<u8>>) -> Result<Option<HashMap<String, String>>, MemcacheError> {
         let key = key.into();
         let index = self.connection_index(&key);
-        let response = self.connections[index].execute(&build_debug(key)?)?;
+        let command = build_debug(key)?;
+        let response = self.with_connection(index, |connection| connection.execute(&command))?;
         parse_debug_result(&response)
     }
 }
@@ -215,7 +283,7 @@ impl<'a, O: Operation> Request<'a, MetaClient, O> {
 #[cfg(test)]
 mod tests {
     use std::io::{BufRead, BufReader, Read, Write};
-    use std::net::{SocketAddr, TcpListener};
+    use std::net::TcpListener;
     use std::thread::JoinHandle;
 
     use super::super::result::{GetStatus, MutationStatus};
@@ -283,6 +351,8 @@ mod tests {
 
     #[test]
     fn client_roundtrip() {
+        // A single accepted connection serves every operation: the pool
+        // reuses it across the whole test.
         let (addr, server) = scripted_server(vec![
             b"HD\r\n",
             b"VA 3 f0\r\nbar\r\n",
@@ -291,7 +361,7 @@ mod tests {
             b"HD\r\n",
             b"MN\r\n",
         ]);
-        let mut client = MetaClient::connect(addr).unwrap();
+        let client = MetaClient::connect(addr).unwrap();
 
         let stored = client.set("foo", "bar").send().unwrap();
         assert_eq!(stored.status, MutationStatus::Stored);
@@ -323,7 +393,7 @@ mod tests {
     #[test]
     fn run_batch_mixed_operations() {
         let (addr, server) = scripted_server(vec![b"HD\r\n", b"VA 1 f0\r\n1\r\n", b"NF\r\n"]);
-        let mut client = MetaClient::connect(addr).unwrap();
+        let client = MetaClient::connect(addr).unwrap();
 
         let results = client
             .run_batch(vec![
@@ -347,7 +417,7 @@ mod tests {
     #[test]
     fn run_batch_validates_before_writing() {
         let (addr, server) = scripted_server(vec![b"MN\r\n"]);
-        let mut client = MetaClient::connect(addr).unwrap();
+        let client = MetaClient::connect(addr).unwrap();
 
         // The second operation is invalid; nothing must reach the server.
         let error = client.run_batch(vec![Set::new("a", "1").into(), Delete::new("b").stale_for(30).into()]);
@@ -361,7 +431,7 @@ mod tests {
     #[test]
     fn run_executes_standalone_operations() {
         let (addr, server) = scripted_server(vec![b"HD\r\n", b"VA 1\r\n1\r\n"]);
-        let mut client = MetaClient::connect(addr).unwrap();
+        let client = MetaClient::connect(addr).unwrap();
 
         let operation = client.set("foo", "bar").ttl(60).into_operation();
         assert!(client.run(operation).unwrap().stored());
@@ -378,7 +448,7 @@ mod tests {
     fn multi_server_routes_by_key() {
         let (addr0, server0) = scripted_server(vec![b"HD\r\n", b"MN\r\n"]);
         let (addr1, server1) = scripted_server(vec![b"VA 1 f0\r\nx\r\n", b"MN\r\n"]);
-        let mut client = MetaClient::connect_multiple([addr0, addr1])
+        let client = MetaClient::connect_multiple([addr0, addr1])
             .unwrap()
             .with_hash_function(first_byte);
         let key0 = format!("{}a", char_for(0));
@@ -402,7 +472,7 @@ mod tests {
     fn multi_server_batch_splits_and_reorders() {
         let (addr0, server0) = scripted_server(vec![b"EN\r\n"]);
         let (addr1, server1) = scripted_server(vec![b"HD\r\n", b"NF\r\n"]);
-        let mut client = MetaClient::connect_multiple([addr0, addr1])
+        let client = MetaClient::connect_multiple([addr0, addr1])
             .unwrap()
             .with_hash_function(first_byte);
         let key_set = format!("{}a", char_for(1));
@@ -437,5 +507,67 @@ mod tests {
     #[test]
     fn connect_multiple_rejects_empty() {
         assert!(MetaClient::connect_multiple(Vec::<SocketAddr>::new()).is_err());
+    }
+
+    #[test]
+    fn poisoned_connection_is_not_reused() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            // First connection (dialed eagerly at connect): serve one bogus
+            // response, which must poison it.
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = Vec::new();
+            reader.read_until(b'\n', &mut line).unwrap();
+            reader.get_mut().write_all(b"BOGUS\r\n").unwrap();
+            // The next operation must arrive on a fresh connection.
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = Vec::new();
+            reader.read_until(b'\n', &mut line).unwrap();
+            reader.get_mut().write_all(b"HD\r\n").unwrap();
+        });
+
+        let client = MetaClient::connect(addr).unwrap();
+        assert!(client.get("foo").send().is_err());
+        assert!(client.delete("foo").send().unwrap().stored());
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn framed_parse_error_keeps_connection() {
+        // "cabc" is a complete response line with an unparsable CAS flag:
+        // the decode fails but the stream stays synchronized, so the same
+        // connection serves the next operation.
+        let (addr, server) = scripted_server(vec![b"HD cabc\r\n", b"HD\r\n"]);
+        let client = MetaClient::connect(addr).unwrap();
+
+        assert!(client.delete("foo").send().is_err());
+        assert!(client.delete("foo").send().unwrap().stored());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn max_idle_zero_never_reuses() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            // With max_idle 0 nothing is retained after use: the first
+            // operation rides the eager connect-time dial, the second must
+            // arrive on a fresh connection.
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().unwrap();
+                let mut reader = BufReader::new(stream);
+                let mut line = Vec::new();
+                reader.read_until(b'\n', &mut line).unwrap();
+                reader.get_mut().write_all(b"HD\r\n").unwrap();
+            }
+        });
+
+        let client = MetaClient::connect(addr).unwrap().with_max_idle(0);
+        assert!(client.delete("foo").send().unwrap().stored());
+        assert!(client.delete("foo").send().unwrap().stored());
+        handle.join().unwrap();
     }
 }

--- a/src/exp/core.rs
+++ b/src/exp/core.rs
@@ -142,6 +142,34 @@ fn invalid<T>(message: &'static str) -> Result<T, MemcacheError> {
     Err(ClientError::Error(Cow::Borrowed(message)).into())
 }
 
+/// A validated batch: every operation prepared into a wire command, and the
+/// operation indexes grouped per server. Shared by both clients.
+pub(crate) struct BatchPlan {
+    /// One prepared command per operation; entries are taken as groups
+    /// execute.
+    pub(crate) commands: Vec<Option<MetaCommand>>,
+    /// Operation indexes per server, in input order.
+    pub(crate) groups: Vec<Vec<usize>>,
+}
+
+/// Prepare and group a batch. Validates every operation before anything is
+/// written, so a bad option never leaves half a batch on the wire.
+pub(crate) fn plan<O: Operation>(
+    operations: &[O],
+    servers: usize,
+    index_for: impl Fn(&[u8]) -> usize,
+) -> Result<BatchPlan, MemcacheError> {
+    let mut commands = Vec::with_capacity(operations.len());
+    for operation in operations {
+        commands.push(Some(operation.prepare()?));
+    }
+    let mut groups: Vec<Vec<usize>> = vec![Vec::new(); servers];
+    for (index, operation) in operations.iter().enumerate() {
+        groups[index_for(operation.key())].push(index);
+    }
+    Ok(BatchPlan { commands, groups })
+}
+
 fn unexpected<T>(message: &'static str) -> Result<T, MemcacheError> {
     Err(ServerError::BadResponse(Cow::Borrowed(message)).into())
 }

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -28,6 +28,11 @@ Clients connected to several servers (`connect_multiple`) route each key by
 a pluggable hash function and split batches per server, one round trip
 each.
 
+Clients are cheap to clone and shareable across threads or tasks; clones
+share per-server pools of idle connections (capped by `with_max_idle`).
+Checkout never blocks: a busy pool just dials another connection. A
+connection that fails mid-exchange is dropped instead of reused.
+
 Transports are TCP only.
 
 # Example

--- a/src/exp/request.rs
+++ b/src/exp/request.rs
@@ -13,12 +13,12 @@ use super::operation::{Arithmetic, Delete, Get, Meta, Set};
 /// An operation bound to a client, awaiting [`send`](Request::send).
 #[must_use = "a request does nothing until you call .send()"]
 pub struct Request<'a, C, O> {
-    pub(crate) client: &'a mut C,
+    pub(crate) client: &'a C,
     pub(crate) operation: O,
 }
 
 impl<'a, C, O> Request<'a, C, O> {
-    pub(crate) fn new(client: &'a mut C, operation: O) -> Request<'a, C, O> {
+    pub(crate) fn new(client: &'a C, operation: O) -> Request<'a, C, O> {
         Request { client, operation }
     }
 

--- a/tests/test_exp.rs
+++ b/tests/test_exp.rs
@@ -13,7 +13,7 @@ fn gen_random_key() -> String {
 
 #[test]
 fn exp_set_get_delete() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     client.noop().unwrap();
@@ -36,7 +36,7 @@ fn exp_set_get_delete() {
 
 #[test]
 fn exp_store_modes() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     assert_eq!(
@@ -58,7 +58,7 @@ fn exp_store_modes() {
 
 #[test]
 fn exp_cas_flow() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     let stored = client.set(&*key, "one").return_cas().send().unwrap();
@@ -80,7 +80,7 @@ fn exp_cas_flow() {
 
 #[test]
 fn exp_arithmetic() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     assert_eq!(client.increment(&*key).send().unwrap().status, MutationStatus::NotFound);
@@ -97,7 +97,7 @@ fn exp_arithmetic() {
 
 #[test]
 fn exp_item_meta() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     client.set(&*key, "bar").ttl(100).send().unwrap();
@@ -119,7 +119,7 @@ fn exp_item_meta() {
 
 #[test]
 fn exp_binary_key() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = format!("{} with spaces\x01", gen_random_key());
 
     assert!(client.set(&*key, "bar").send().unwrap().stored());
@@ -130,7 +130,7 @@ fn exp_binary_key() {
 
 #[test]
 fn exp_run_batch() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key_a = gen_random_key();
     let key_b = gen_random_key();
 
@@ -152,7 +152,7 @@ fn exp_run_batch() {
 
 #[test]
 fn exp_lease() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     // First reader vivifies the key and wins the lease.
@@ -173,7 +173,7 @@ fn exp_lease() {
 
 #[test]
 fn exp_typed_values() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     // Numbers are stored as decimal ASCII, so arithmetic works on them.
@@ -193,7 +193,7 @@ fn exp_typed_values() {
 
 #[test]
 fn exp_multi_server() {
-    let mut client = MetaClient::connect_multiple(["localhost:12345", "localhost:12346"]).unwrap();
+    let client = MetaClient::connect_multiple(["localhost:12345", "localhost:12346"]).unwrap();
     client.noop().unwrap();
 
     let keys: Vec<String> = (0..20).map(|_| gen_random_key()).collect();
@@ -219,8 +219,27 @@ fn exp_multi_server() {
 }
 
 #[test]
+fn exp_concurrent_clients() {
+    let client = MetaClient::connect(SERVER).unwrap();
+    std::thread::scope(|scope| {
+        for _ in 0..4 {
+            let client = client.clone();
+            scope.spawn(move || {
+                for _ in 0..10 {
+                    let key = gen_random_key();
+                    assert!(client.set(key.as_str(), "v").send().unwrap().stored());
+                    let fetched = client.get(key.as_str()).send().unwrap();
+                    assert_eq!(fetched.value.as_deref(), Some(&b"v"[..]));
+                    assert!(client.delete(key.as_str()).send().unwrap().stored());
+                }
+            });
+        }
+    });
+}
+
+#[test]
 fn exp_debug() {
-    let mut client = MetaClient::connect(SERVER).unwrap();
+    let client = MetaClient::connect(SERVER).unwrap();
     let key = gen_random_key();
 
     assert!(client.debug(&*key).unwrap().is_none());
@@ -236,7 +255,7 @@ mod async_tests {
 
     #[tokio::test]
     async fn exp_async_roundtrip() {
-        let mut client = AsyncMetaClient::connect(SERVER).await.unwrap();
+        let client = AsyncMetaClient::connect(SERVER).await.unwrap();
         let key = gen_random_key();
 
         client.noop().await.unwrap();


### PR DESCRIPTION
Make the exp clients cloneable and shareable by pooling connections per server.

- Each server keeps a stack of idle connections behind a mutex: checkout pops one or dials a new connection (never blocks), return keeps it only while under `with_max_idle` (default 8); there is no cap on concurrent connections, only on retained idle ones, so batches can never deadlock on checkout
- A connection that fails mid-exchange (io error, EOF, framing error) is dropped instead of reused, since the stream state is unknown; errors after a completely framed response keep the connection
- Both clients are now `Clone + Send + Sync` with all methods on `&self`; clones share the pools; `from_connection` is removed since a pooled client needs a dialable address
- Addresses are resolved eagerly at connect time and one connection per server is dialed up front, so connection errors still surface at `connect`
- The duplicated batch prepare/grouping logic moves into a shared `plan()` in the core