### PR TITLE
Add connect and I/O timeouts to exp module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.10"
 enum_dispatch = "0.3"
 openssl = { version = "^0.10", optional = true }
 r2d2 = "^0.8"
-tokio = { version = "1", features = ["io-util", "net"], optional = true }
+tokio = { version = "1", features = ["io-util", "net", "time"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["io-util", "net", "rt", "macros"] }
+tokio = { version = "1", features = ["io-util", "net", "rt", "macros", "time"] }

--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -133,20 +133,20 @@ impl AsyncMetaClient {
         self
     }
 
-    /// Limit how long dialing a server may take (no limit by default).
-    /// Configure before cloning: clones share connections but not this
-    /// setting.
-    pub fn with_connect_timeout(mut self, timeout: Duration) -> AsyncMetaClient {
-        self.timeouts.connect = Some(timeout);
+    /// Limit how long dialing a server may take (default 1 second; `None`
+    /// removes the limit). Configure before cloning: clones share
+    /// connections but not this setting.
+    pub fn with_connect_timeout(mut self, timeout: Option<Duration>) -> AsyncMetaClient {
+        self.timeouts.connect = timeout;
         self
     }
 
-    /// Limit how long one command or batch exchange may take (no limit by
-    /// default). A timeout poisons the connection like any other transport
-    /// error. Configure before cloning: clones share connections but not
-    /// this setting.
-    pub fn with_io_timeout(mut self, timeout: Duration) -> AsyncMetaClient {
-        self.timeouts.io = Some(timeout);
+    /// Limit how long one command or batch exchange may take (default 1
+    /// second; `None` removes the limit). A timeout poisons the connection
+    /// like any other transport error. Configure before cloning: clones
+    /// share connections but not this setting.
+    pub fn with_io_timeout(mut self, timeout: Option<Duration>) -> AsyncMetaClient {
+        self.timeouts.io = timeout;
         self
     }
 
@@ -297,7 +297,7 @@ mod tests {
         let client = AsyncMetaClient::connect(addr)
             .await
             .unwrap()
-            .with_io_timeout(Duration::from_millis(100));
+            .with_io_timeout(Some(Duration::from_millis(100)));
         assert!(client.delete("foo").send().await.is_err());
         assert!(client.delete("foo").send().await.unwrap().stored());
         handle.join().unwrap();

--- a/src/exp/async_client.rs
+++ b/src/exp/async_client.rs
@@ -2,15 +2,17 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use tokio::net::{ToSocketAddrs, lookup_host};
 
 use crate::error::{ClientError, MemcacheError, ServerError};
 
 use super::async_connection::AsyncMetaConnection;
-use super::client::{DEFAULT_MAX_IDLE, default_hash_function, jump_hash};
+use super::client::{DEFAULT_MAX_IDLE, Timeouts, default_hash_function, jump_hash};
 use super::core::{self, Operation};
 use super::meta_api::{ArithmeticMode, build_debug, build_noop, parse_debug_result, parse_meta_result};
 use super::meta_command::{MetaCommand, ReturnCode};
@@ -18,6 +20,22 @@ use super::operation::{Arithmetic, Delete, Get, Op, Set};
 use super::request::Request;
 use super::result::OpResult;
 use super::value::ToValue;
+
+/// Bound a transport future by a timeout; `None` means unbounded. A
+/// timeout surfaces as an io error and so poisons the connection like any
+/// other transport failure.
+async fn timed<T>(
+    timeout: Option<Duration>,
+    future: impl Future<Output = Result<T, MemcacheError>>,
+) -> Result<T, MemcacheError> {
+    match timeout {
+        Some(duration) => match tokio::time::timeout(duration, future).await {
+            Ok(result) => result,
+            Err(_) => Err(std::io::Error::from(std::io::ErrorKind::TimedOut).into()),
+        },
+        None => future.await,
+    }
+}
 
 /// One server: its resolved addresses and a stack of idle connections.
 /// The mutex is only held to pop/push, never across I/O.
@@ -27,12 +45,12 @@ struct AsyncServer {
 }
 
 impl AsyncServer {
-    async fn checkout(&self) -> Result<AsyncMetaConnection, MemcacheError> {
+    async fn checkout(&self, timeouts: &Timeouts) -> Result<AsyncMetaConnection, MemcacheError> {
         let reused = self.idle.lock().unwrap().pop();
         if let Some(connection) = reused {
             return Ok(connection);
         }
-        AsyncMetaConnection::connect(self.addrs.as_slice()).await
+        timed(timeouts.connect, AsyncMetaConnection::connect(self.addrs.as_slice())).await
     }
 
     fn put_back(&self, connection: AsyncMetaConnection, max_idle: usize) {
@@ -61,6 +79,7 @@ pub struct AsyncMetaClient {
     servers: Arc<Vec<AsyncServer>>,
     hash_function: fn(&[u8]) -> u64,
     max_idle: usize,
+    timeouts: Timeouts,
 }
 
 impl AsyncMetaClient {
@@ -69,8 +88,8 @@ impl AsyncMetaClient {
     }
 
     /// Connect to several servers; keys are distributed across them by the
-    /// hash function. One connection per server is dialed up front so
-    /// connection errors surface here.
+    /// hash function. Addresses are resolved here, but connections are
+    /// dialed lazily, so a down server surfaces at the first operation.
     pub async fn connect_multiple<A: ToSocketAddrs>(
         addrs: impl IntoIterator<Item = A>,
     ) -> Result<AsyncMetaClient, MemcacheError> {
@@ -80,13 +99,10 @@ impl AsyncMetaClient {
             if resolved.is_empty() {
                 return Err(ClientError::Error(Cow::Borrowed("address resolved to no socket addresses")).into());
             }
-            let server = AsyncServer {
+            servers.push(AsyncServer {
                 addrs: resolved,
                 idle: Mutex::new(Vec::new()),
-            };
-            let connection = AsyncMetaConnection::connect(server.addrs.as_slice()).await?;
-            server.idle.lock().unwrap().push(connection);
-            servers.push(server);
+            });
         }
         if servers.is_empty() {
             return Err(ClientError::Error(Cow::Borrowed("at least one server address is required")).into());
@@ -95,6 +111,7 @@ impl AsyncMetaClient {
             servers: Arc::new(servers),
             hash_function: default_hash_function,
             max_idle: DEFAULT_MAX_IDLE,
+            timeouts: Timeouts::default(),
         })
     }
 
@@ -113,6 +130,23 @@ impl AsyncMetaClient {
     /// but not this setting.
     pub fn with_max_idle(mut self, max_idle: usize) -> AsyncMetaClient {
         self.max_idle = max_idle;
+        self
+    }
+
+    /// Limit how long dialing a server may take (no limit by default).
+    /// Configure before cloning: clones share connections but not this
+    /// setting.
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> AsyncMetaClient {
+        self.timeouts.connect = Some(timeout);
+        self
+    }
+
+    /// Limit how long one command or batch exchange may take (no limit by
+    /// default). A timeout poisons the connection like any other transport
+    /// error. Configure before cloning: clones share connections but not
+    /// this setting.
+    pub fn with_io_timeout(mut self, timeout: Duration) -> AsyncMetaClient {
+        self.timeouts.io = Some(timeout);
         self
     }
 
@@ -155,10 +189,10 @@ impl AsyncMetaClient {
     pub async fn run<O: Operation>(&self, operation: O) -> Result<O::Output, MemcacheError> {
         let command = operation.prepare()?;
         let server = &self.servers[self.connection_index(operation.key())];
-        let mut connection = server.checkout().await?;
+        let mut connection = server.checkout(&self.timeouts).await?;
         // A failed exchange leaves the stream in an unknown state, so the
         // connection is dropped instead of returned to the pool.
-        let response = connection.execute(&command).await?;
+        let response = timed(self.timeouts.io, connection.execute(&command)).await?;
         server.put_back(connection, self.max_idle);
         operation.parse(parse_meta_result(response)?)
     }
@@ -187,8 +221,8 @@ impl AsyncMetaClient {
                 .map(|&index| plan.commands[index].take().unwrap())
                 .collect();
             let server = &self.servers[server];
-            let mut connection = server.checkout().await?;
-            let responses = connection.execute_batch(&commands).await?;
+            let mut connection = server.checkout(&self.timeouts).await?;
+            let responses = timed(self.timeouts.io, connection.execute_batch(&commands)).await?;
             server.put_back(connection, self.max_idle);
             for (&index, response) in indices.iter().zip(responses) {
                 outputs[index] = Some(operations[index].parse(parse_meta_result(response)?)?);
@@ -204,8 +238,8 @@ impl AsyncMetaClient {
     /// health check.
     pub async fn noop(&self) -> Result<(), MemcacheError> {
         for server in self.servers.iter() {
-            let mut connection = server.checkout().await?;
-            let response = connection.execute(&build_noop()).await?;
+            let mut connection = server.checkout(&self.timeouts).await?;
+            let response = timed(self.timeouts.io, connection.execute(&build_noop())).await?;
             server.put_back(connection, self.max_idle);
             if response.rc != ReturnCode::Mn {
                 return Err(ServerError::BadResponse("unexpected no-op response".into()).into());
@@ -219,8 +253,8 @@ impl AsyncMetaClient {
         let key = key.into();
         let server = &self.servers[self.connection_index(&key)];
         let command = build_debug(key)?;
-        let mut connection = server.checkout().await?;
-        let response = connection.execute(&command).await?;
+        let mut connection = server.checkout(&self.timeouts).await?;
+        let response = timed(self.timeouts.io, connection.execute(&command)).await?;
         server.put_back(connection, self.max_idle);
         parse_debug_result(&response)
     }
@@ -231,5 +265,41 @@ impl<'a, O: Operation> Request<'a, AsyncMetaClient, O> {
     pub async fn send(self) -> Result<O::Output, MemcacheError> {
         let Request { client, operation } = self;
         client.run(operation).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn io_timeout_poisons_connection() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            // First connection: read the request but never respond, so the
+            // exchange times out and the connection is poisoned.
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = Vec::new();
+            reader.read_until(b'\n', &mut line).unwrap();
+            // Second connection: respond normally.
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = Vec::new();
+            reader.read_until(b'\n', &mut line).unwrap();
+            reader.get_mut().write_all(b"HD\r\n").unwrap();
+        });
+
+        let client = AsyncMetaClient::connect(addr)
+            .await
+            .unwrap()
+            .with_io_timeout(Duration::from_millis(100));
+        assert!(client.delete("foo").send().await.is_err());
+        assert!(client.delete("foo").send().await.unwrap().stored());
+        handle.join().unwrap();
     }
 }

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -4,8 +4,9 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::error::{ClientError, MemcacheError, ServerError};
 
@@ -59,11 +60,38 @@ struct Server {
 }
 
 impl Server {
-    fn checkout(&self) -> Result<MetaConnection, MemcacheError> {
-        if let Some(connection) = self.idle.lock().unwrap().pop() {
-            return Ok(connection);
-        }
-        MetaConnection::connect(self.addrs.as_slice())
+    fn checkout(&self, timeouts: &Timeouts) -> Result<MetaConnection, MemcacheError> {
+        let connection = match self.idle.lock().unwrap().pop() {
+            Some(connection) => connection,
+            None => self.dial(timeouts)?,
+        };
+        // The socket timeouts follow the client's current setting, also for
+        // connections dialed before it was configured.
+        connection.set_io_timeout(timeouts.io)?;
+        Ok(connection)
+    }
+
+    fn dial(&self, timeouts: &Timeouts) -> Result<MetaConnection, MemcacheError> {
+        let stream = match timeouts.connect {
+            Some(duration) => {
+                let mut last_error = None;
+                let mut connected = None;
+                for addr in &self.addrs {
+                    match TcpStream::connect_timeout(addr, duration) {
+                        Ok(stream) => {
+                            connected = Some(stream);
+                            break;
+                        }
+                        Err(error) => last_error = Some(error),
+                    }
+                }
+                // `addrs` is never empty, so a miss always has an error.
+                connected.ok_or_else(|| last_error.unwrap())?
+            }
+            None => TcpStream::connect(self.addrs.as_slice())?,
+        };
+        stream.set_nodelay(true)?;
+        Ok(MetaConnection::from_stream(stream))
     }
 
     fn put_back(&self, connection: MetaConnection, max_idle: usize) {
@@ -72,6 +100,12 @@ impl Server {
             idle.push(connection);
         }
     }
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct Timeouts {
+    pub(crate) connect: Option<Duration>,
+    pub(crate) io: Option<Duration>,
 }
 
 /// A blocking meta protocol client.
@@ -98,6 +132,7 @@ pub struct MetaClient {
     servers: Arc<Vec<Server>>,
     hash_function: fn(&[u8]) -> u64,
     max_idle: usize,
+    timeouts: Timeouts,
 }
 
 impl MetaClient {
@@ -106,18 +141,15 @@ impl MetaClient {
     }
 
     /// Connect to several servers; keys are distributed across them by the
-    /// hash function. One connection per server is dialed up front so
-    /// connection errors surface here.
+    /// hash function. Addresses are resolved here, but connections are
+    /// dialed lazily, so a down server surfaces at the first operation.
     pub fn connect_multiple<A: ToSocketAddrs>(addrs: impl IntoIterator<Item = A>) -> Result<MetaClient, MemcacheError> {
         let mut servers = Vec::new();
         for addr in addrs {
-            let server = Server {
+            servers.push(Server {
                 addrs: resolve(addr)?,
                 idle: Mutex::new(Vec::new()),
-            };
-            let connection = MetaConnection::connect(server.addrs.as_slice())?;
-            server.idle.lock().unwrap().push(connection);
-            servers.push(server);
+            });
         }
         if servers.is_empty() {
             return Err(ClientError::Error(Cow::Borrowed("at least one server address is required")).into());
@@ -126,6 +158,7 @@ impl MetaClient {
             servers: Arc::new(servers),
             hash_function: default_hash_function,
             max_idle: DEFAULT_MAX_IDLE,
+            timeouts: Timeouts::default(),
         })
     }
 
@@ -147,6 +180,23 @@ impl MetaClient {
         self
     }
 
+    /// Limit how long dialing a server may take (no limit by default).
+    /// Configure before cloning: clones share connections but not this
+    /// setting.
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> MetaClient {
+        self.timeouts.connect = Some(timeout);
+        self
+    }
+
+    /// Limit how long a single socket read or write may take (no limit by
+    /// default). A timeout poisons the connection like any other transport
+    /// error. Configure before cloning: clones share connections but not
+    /// this setting.
+    pub fn with_io_timeout(mut self, timeout: Duration) -> MetaClient {
+        self.timeouts.io = Some(timeout);
+        self
+    }
+
     fn connection_index(&self, key: &[u8]) -> usize {
         jump_hash((self.hash_function)(key), self.servers.len())
     }
@@ -160,7 +210,7 @@ impl MetaClient {
         exchange: impl FnOnce(&mut MetaConnection) -> Result<T, MemcacheError>,
     ) -> Result<T, MemcacheError> {
         let server = &self.servers[server];
-        let mut connection = server.checkout()?;
+        let mut connection = server.checkout(&self.timeouts)?;
         let result = exchange(&mut connection);
         if result.is_ok() {
             server.put_back(connection, self.max_idle);
@@ -510,12 +560,53 @@ mod tests {
     }
 
     #[test]
+    fn io_timeout_poisons_connection() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            // First connection: read the request but never respond, so the
+            // read times out and the connection is poisoned.
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = Vec::new();
+            reader.read_until(b'\n', &mut line).unwrap();
+            // Second connection: respond normally.
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream);
+            let mut line = Vec::new();
+            reader.read_until(b'\n', &mut line).unwrap();
+            reader.get_mut().write_all(b"HD\r\n").unwrap();
+        });
+
+        let client = MetaClient::connect(addr)
+            .unwrap()
+            .with_io_timeout(Duration::from_millis(100));
+        let start = std::time::Instant::now();
+        assert!(client.delete("foo").send().is_err());
+        assert!(start.elapsed() < Duration::from_secs(5));
+        assert!(client.delete("foo").send().unwrap().stored());
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn connect_timeout_fails_fast() {
+        // TEST-NET-1 (192.0.2.0/24) is reserved and unroutable, so the dial
+        // either times out or is rejected outright; it must not hang.
+        let client = MetaClient::connect("192.0.2.1:11211")
+            .unwrap()
+            .with_connect_timeout(Duration::from_millis(100));
+        let start = std::time::Instant::now();
+        assert!(client.delete("foo").send().is_err());
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
     fn poisoned_connection_is_not_reused() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         let handle = std::thread::spawn(move || {
-            // First connection (dialed eagerly at connect): serve one bogus
-            // response, which must poison it.
+            // First connection (dialed by the first operation): serve one
+            // bogus response, which must poison it.
             let (stream, _) = listener.accept().unwrap();
             let mut reader = BufReader::new(stream);
             let mut line = Vec::new();
@@ -553,9 +644,8 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         let handle = std::thread::spawn(move || {
-            // With max_idle 0 nothing is retained after use: the first
-            // operation rides the eager connect-time dial, the second must
-            // arrive on a fresh connection.
+            // With max_idle 0 nothing is retained after use: every
+            // operation must arrive on its own fresh connection.
             for _ in 0..2 {
                 let (stream, _) = listener.accept().unwrap();
                 let mut reader = BufReader::new(stream);

--- a/src/exp/client.rs
+++ b/src/exp/client.rs
@@ -102,10 +102,24 @@ impl Server {
     }
 }
 
-#[derive(Clone, Copy, Default)]
+/// Cache operations normally complete in milliseconds, so one second is
+/// already a generous bound; a hung cache server should fail fast rather
+/// than stall its callers.
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Copy)]
 pub(crate) struct Timeouts {
     pub(crate) connect: Option<Duration>,
     pub(crate) io: Option<Duration>,
+}
+
+impl Default for Timeouts {
+    fn default() -> Timeouts {
+        Timeouts {
+            connect: Some(DEFAULT_TIMEOUT),
+            io: Some(DEFAULT_TIMEOUT),
+        }
+    }
 }
 
 /// A blocking meta protocol client.
@@ -180,20 +194,20 @@ impl MetaClient {
         self
     }
 
-    /// Limit how long dialing a server may take (no limit by default).
-    /// Configure before cloning: clones share connections but not this
-    /// setting.
-    pub fn with_connect_timeout(mut self, timeout: Duration) -> MetaClient {
-        self.timeouts.connect = Some(timeout);
+    /// Limit how long dialing a server may take (default 1 second; `None`
+    /// removes the limit). Configure before cloning: clones share
+    /// connections but not this setting.
+    pub fn with_connect_timeout(mut self, timeout: Option<Duration>) -> MetaClient {
+        self.timeouts.connect = timeout;
         self
     }
 
-    /// Limit how long a single socket read or write may take (no limit by
-    /// default). A timeout poisons the connection like any other transport
-    /// error. Configure before cloning: clones share connections but not
-    /// this setting.
-    pub fn with_io_timeout(mut self, timeout: Duration) -> MetaClient {
-        self.timeouts.io = Some(timeout);
+    /// Limit how long a single socket read or write may take (default 1
+    /// second; `None` removes the limit). A timeout poisons the connection
+    /// like any other transport error. Configure before cloning: clones
+    /// share connections but not this setting.
+    pub fn with_io_timeout(mut self, timeout: Option<Duration>) -> MetaClient {
+        self.timeouts.io = timeout;
         self
     }
 
@@ -580,7 +594,7 @@ mod tests {
 
         let client = MetaClient::connect(addr)
             .unwrap()
-            .with_io_timeout(Duration::from_millis(100));
+            .with_io_timeout(Some(Duration::from_millis(100)));
         let start = std::time::Instant::now();
         assert!(client.delete("foo").send().is_err());
         assert!(start.elapsed() < Duration::from_secs(5));
@@ -594,7 +608,7 @@ mod tests {
         // either times out or is rejected outright; it must not hang.
         let client = MetaClient::connect("192.0.2.1:11211")
             .unwrap()
-            .with_connect_timeout(Duration::from_millis(100));
+            .with_connect_timeout(Some(Duration::from_millis(100)));
         let start = std::time::Instant::now();
         assert!(client.delete("foo").send().is_err());
         assert!(start.elapsed() < Duration::from_secs(5));

--- a/src/exp/connection.rs
+++ b/src/exp/connection.rs
@@ -31,6 +31,13 @@ impl MetaConnection {
         }
     }
 
+    /// Set (or clear) the read/write timeouts on the underlying socket.
+    pub(crate) fn set_io_timeout(&self, timeout: Option<std::time::Duration>) -> Result<(), MemcacheError> {
+        self.reader.get_ref().set_read_timeout(timeout)?;
+        self.reader.get_ref().set_write_timeout(timeout)?;
+        Ok(())
+    }
+
     /// Encode and write a single command.
     pub fn send(&mut self, command: &MetaCommand) -> Result<(), MemcacheError> {
         let payload = command.encode()?;

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -32,6 +32,8 @@ Clients are cheap to clone and shareable across threads or tasks; clones
 share per-server pools of idle connections (capped by `with_max_idle`).
 Checkout never blocks: a busy pool just dials another connection. A
 connection that fails mid-exchange is dropped instead of reused.
+Connections are dialed lazily; `with_connect_timeout` and
+`with_io_timeout` bound dialing and I/O (unbounded by default).
 
 Transports are TCP only.
 

--- a/src/exp/mod.rs
+++ b/src/exp/mod.rs
@@ -33,7 +33,8 @@ share per-server pools of idle connections (capped by `with_max_idle`).
 Checkout never blocks: a busy pool just dials another connection. A
 connection that fails mid-exchange is dropped instead of reused.
 Connections are dialed lazily; `with_connect_timeout` and
-`with_io_timeout` bound dialing and I/O (unbounded by default).
+`with_io_timeout` bound dialing and I/O (1 second by default, `None`
+removes the limit).
 
 Transports are TCP only.
 


### PR DESCRIPTION
Bound dialing and I/O in the exp clients. Both default to 1 second; pass `None` to remove the limit.

- `with_connect_timeout` limits dialing: sync via `TcpStream::connect_timeout` over the resolved addresses, tokio via `tokio::time::timeout` around the dial
- `with_io_timeout` limits I/O: sync via the socket read/write timeouts (applied at checkout, so the setting reaches connections dialed earlier), tokio by bounding each command or batch exchange; a timeout poisons the connection like any other transport error
- Cache operations normally complete in milliseconds, so a hung server fails fast by default instead of stalling callers
- Connections are now dialed lazily instead of eagerly at `connect`, since builder-style timeout settings happen after `connect` and would never reach the first dial; a down server surfaces at the first operation